### PR TITLE
Fix bug introduced with #39

### DIFF
--- a/src/posix/tty.rs
+++ b/src/posix/tty.rs
@@ -70,7 +70,9 @@ impl Drop for OwnedFd {
 
 impl OwnedFd {
     fn into_raw(self) -> RawFd {
-        self.0
+        let fd = self.0;
+        mem::forget(self);
+        fd
     }
 }
 


### PR DESCRIPTION
If opening succeeded, automatic closing on drop must be skipped.