### PR TITLE
Set port timeout to a non-zero value before performing loopback test.

### DIFF
--- a/examples/hardware_check.rs
+++ b/examples/hardware_check.rs
@@ -247,11 +247,13 @@ fn test_single_port(port: &mut dyn serialport::SerialPort, loopback: bool) {
         .expect("Unable to write bytes.");
     println!("success");
 
-    print!("Testing data reception...");
     if loopback {
+        print!("Testing data reception...");
+        port.set_timeout(Duration::from_millis(250)).ok();
+
         let mut buf = [0u8; 12];
-        if port.read_exact(&mut buf).is_err() {
-            println!("FAILED");
+        if let Err(e) = port.read_exact(&mut buf) {
+            println!("FAILED ({})", e);
         } else {
             assert_eq!(
                 str::from_utf8(&buf).unwrap(),


### PR DESCRIPTION
Default port timeout of zero may cause the hardware_check example to fail
when reading data with the '--loopback' flag. Added 250ms timeout delay to
allow the test to pass when data is not immediately available.

This patch additionally includes two QoL changes:

1. Only print 'testing data reception...' when test is actually performed
2. Print the cause when reading data encounters an exception

Fixes #25

For further comments, see:

https://github.com/serialport/serialport-rs/issues/25#issuecomment-1104661967

Signed-off-by: mlsvrts <mlsvrts@protonmail.com>