### PR TITLE
Add serde support behind a feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["hardware-support"]
 [target."cfg(unix)".dependencies]
 bitflags = "1.3.2"
 cfg-if = "1.0.0"
-nix = "0.23.1"
+nix = { version = "0.24.1", default-features = false, features = ["fs", "ioctl", "poll", "signal", "term"] }
 
 [target.'cfg(all(target_os = "linux", not(target_env = "musl")))'.dependencies]
 libudev = { version = "0.3.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,9 @@ features = [
     "minwindef", "ntdef", "setupapi", "winbase", "winerror", "winnt",
 ]
 
+[dependencies]
+serde = { version = "1.0", features = ["derive"], optional = true }
+
 [dev-dependencies]
 clap = "3.1.6"
 

--- a/examples/hardware_check.rs
+++ b/examples/hardware_check.rs
@@ -247,11 +247,13 @@ fn test_single_port(port: &mut dyn serialport::SerialPort, loopback: bool) {
         .expect("Unable to write bytes.");
     println!("success");
 
-    print!("Testing data reception...");
     if loopback {
+        print!("Testing data reception...");
+        port.set_timeout(Duration::from_millis(250)).ok();
+
         let mut buf = [0u8; 12];
-        if port.read_exact(&mut buf).is_err() {
-            println!("FAILED");
+        if let Err(e) = port.read_exact(&mut buf) {
+            println!("FAILED ({})", e);
         } else {
             assert_eq!(
                 str::from_utf8(&buf).unwrap(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,6 +128,7 @@ impl From<Error> for io::Error {
 
 /// Number of bits per character
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum DataBits {
     /// 5 bits per character
     Five,
@@ -152,6 +153,7 @@ pub enum DataBits {
 /// Parity checking is disabled by setting `None`, in which case parity bits are not
 /// transmitted.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Parity {
     /// No parity bit.
     None,
@@ -167,6 +169,7 @@ pub enum Parity {
 ///
 /// Stop bits are transmitted after every character.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum StopBits {
     /// One stop bit.
     One,
@@ -177,6 +180,7 @@ pub enum StopBits {
 
 /// Flow control modes
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum FlowControl {
     /// No flow control.
     None,
@@ -192,6 +196,7 @@ pub enum FlowControl {
 ///
 /// [`clear`]: trait.SerialPort.html#tymethod.clear
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ClearBuffer {
     /// Specify to clear data received but not read
     Input,
@@ -617,6 +622,7 @@ impl<T: SerialPort> SerialPort for &mut T {
 
 /// Contains all possible USB information about a `SerialPort`
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UsbPortInfo {
     /// Vendor ID
     pub vid: u16,
@@ -632,6 +638,7 @@ pub struct UsbPortInfo {
 
 /// The physical type of a `SerialPort`
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum SerialPortType {
     /// The serial port is connected via USB
     UsbPort(UsbPortInfo),
@@ -645,6 +652,7 @@ pub enum SerialPortType {
 
 /// A device-independent implementation of serial port information
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SerialPortInfo {
     /// The short name of the serial port
     pub port_name: String,


### PR DESCRIPTION
Pretty much does what it says on the tin :). 

The dep I've written is `serde = { version = "1.0", features = ["derive"], optional = true }` which I think is fine, but perhaps more versions of serde should be supported?