### PR TITLE
Derive Clone for Error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@ pub enum ErrorKind {
 }
 
 /// An error type for serial port operations
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Error {
     /// The kind of error this is
     pub kind: ErrorKind,


### PR DESCRIPTION
Deriving `Clone` impl for `Error`.

This helps propagating `Error` in certain cases. Also doesn't break anything or block any future development.