### PR TITLE
skip attempts to set baud rate of 0 via ioctl (macos)

### DIFF
--- a/src/posix/tty.rs
+++ b/src/posix/tty.rs
@@ -37,6 +37,21 @@ fn close(fd: RawFd) {
 /// should not be instantiated directly by using `TTYPort::open()`, instead use
 /// the cross-platform `serialport::open()` or
 /// `serialport::open_with_settings()`.
+///
+/// Note: on macOS, when connecting to a pseudo-terminal (`pty` opened via
+/// `posix_openpt`), the `baud_rate` should be set to 0; this will be used to
+/// explicitly _skip_ an attempt to set the baud rate of the file descriptor
+/// that would otherwise happen via an `ioctl` command.
+///
+/// ```
+/// use serialport::{TTYPort, SerialPort};
+///
+/// let (mut master, slave) = TTYPort::pair().expect("Unable to create ptty pair");
+///
+/// // ... elsewhere
+///
+/// let mut port = TTYPort::open(&serialport::new(slave.name().unwrap(), 0)).expect("unable to open");
+/// ```
 #[derive(Debug)]
 pub struct TTYPort {
     fd: RawFd,


### PR DESCRIPTION
On macOS, attempts to set the baud rate of pseudo terminals via normal
ioctl apis appears to be problematic. To support users targeting these
pseudo terminals, this commit adds the ability to use a `baud_rate` of 0
to skip the attempt altogether.

relates to #22 & #49 