### PR TITLE
fix `tiocmget` method

### DIFF
--- a/src/posix/ioctl.rs
+++ b/src/posix/ioctl.rs
@@ -118,8 +118,9 @@ pub fn tiocnxcl(fd: RawFd) -> Result<()> {
 
 pub fn tiocmget(fd: RawFd) -> Result<SerialLines> {
     let mut status: libc::c_int = 0;
-    let x = unsafe { raw::tiocmget(fd, &mut status) };
-    x.map(SerialLines::from_bits_truncate).map_err(|e| e.into())
+    unsafe { raw::tiocmget(fd, &mut status) }
+        .map(|_| SerialLines::from_bits_truncate(status))
+        .map_err(|e| e.into())
 }
 
 pub fn tiocsbrk(fd: RawFd) -> Result<()> {


### PR DESCRIPTION
The method used the `ioctl` return value rather than the reference out argument when constructing the returned bitflags

I noticed the problem when trying to use the `read_ring_indicator` method in a unix project and I was just getting a result of zero. I tested using the raw `ioctl` method and realized the return is actually provided by the reference out argument. 

