### PR TITLE
Fix unicode names

### DIFF
--- a/src/posix/tty.rs
+++ b/src/posix/tty.rs
@@ -79,7 +79,7 @@ struct OwnedFd(RawFd);
 
 impl Drop for OwnedFd {
     fn drop(&mut self) {
-        let _ = close(self.0);
+        close(self.0);
     }
 }
 
@@ -208,12 +208,9 @@ impl TTYPort {
             ioctl::tiocnxcl(self.fd)
         };
 
-        if let Err(err) = setting_result {
-            Err(err)
-        } else {
-            self.exclusive = exclusive;
-            Ok(())
-        }
+        setting_result?;
+        self.exclusive = exclusive;
+        Ok(())
     }
 
     fn set_pin(&mut self, pin: ioctl::SerialLines, level: bool) -> Result<()> {

--- a/src/windows/enumerate.rs
+++ b/src/windows/enumerate.rs
@@ -220,29 +220,28 @@ impl PortDevice {
                 KEY_READ,
             )
         };
-        let mut port_name_buffer = [0u8; MAX_PATH];
+
+        let mut port_name_buffer = [0u16; MAX_PATH];
         let mut port_name_len = port_name_buffer.len() as DWORD;
-        let value_name = CString::new("PortName").unwrap();
+        let value_name: Vec<u16> = "PortName".encode_utf16().chain(Some(0)).collect();
+
         unsafe {
-            RegQueryValueExA(
+            RegQueryValueExW(
                 hkey,
                 value_name.as_ptr(),
                 ptr::null_mut(),
                 ptr::null_mut(),
-                port_name_buffer.as_mut_ptr(),
+                port_name_buffer.as_mut_ptr() as *mut u8,
                 &mut port_name_len,
             )
         };
         unsafe { RegCloseKey(hkey) };
 
-        let mut port_name = &port_name_buffer[0..port_name_len as usize];
+        let port_name = &port_name_buffer[0..port_name_len as usize];
 
-        // Strip any nul bytes from the end of the buffer
-        while port_name.last().map_or(false, |c| *c == b'\0') {
-            port_name = &port_name[..port_name.len() - 1];
-        }
-
-        String::from_utf8_lossy(port_name).into_owned()
+        String::from_utf16_lossy(port_name)
+            .trim_end_matches(0 as char)
+            .to_string()
     }
 
     // Determines the port_type for this device, and if it's a USB port populate the various fields.


### PR DESCRIPTION
Switch to unicode Windows APIs:

The default use of ANSI Windows APIs prevents some device names from displaying correctly; this can be resolved by using the Unicode API calls. Closes #62 