### PR TITLE
Fix for missing `serial_number` on macOS

### DIFF
--- a/src/posix/enumerate.rs
+++ b/src/posix/enumerate.rs
@@ -164,12 +164,18 @@ fn get_string_property(device_type: io_registry_entry_t, property: &str) -> Opti
             return None;
         }
 
-        let str_ptr = CFStringGetCStringPtr(container as CFStringRef, kCFStringEncodingMacRoman);
-        if str_ptr.is_null() {
-            CFRelease(container);
-            return None;
-        }
-        let opt_str = CStr::from_ptr(str_ptr).to_str().ok().map(String::from);
+        let mut buf = Vec::with_capacity(256);
+        let result = CFStringGetCString(
+            container as CFStringRef,
+            buf.as_mut_ptr(),
+            buf.capacity() as i64,
+            kCFStringEncodingUTF8,
+        );
+        let opt_str = if result != 0 {
+            CStr::from_ptr(buf.as_ptr()).to_str().ok().map(String::from)
+        } else {
+            None
+        };
 
         CFRelease(container);
 


### PR DESCRIPTION
`CFStringGetCStringPtr` was used incorrectly on macOS in `get_string_property`.

From https://developer.apple.com/documentation/corefoundation/1542133-cfstringgetcstringptr :

> This function either returns the requested pointer immediately, with no memory allocations and no copying, in constant time, or returns NULL. If the latter is the result, call an alternative function such as the [CFStringGetCString(_:_:_:_:)] function to extract the characters.

As the result `serial_number` is some cases was empty. After switching  to `CFStringGetCString` it now always set correctly .