### PR TITLE
Upgrade nix to 0.25.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["hardware-support"]
 [target."cfg(unix)".dependencies]
 bitflags = "1.3.2"
 cfg-if = "1.0.0"
-nix = { version = "0.24.1", default-features = false, features = ["fs", "ioctl", "poll", "signal", "term"] }
+nix = { version = "0.25.0", default-features = false, features = ["fs", "ioctl", "poll", "signal", "term"] }
 
 [target.'cfg(all(target_os = "linux", not(target_env = "musl")))'.dependencies]
 libudev = { version = "0.3.0", optional = true }

--- a/src/posix/poll.rs
+++ b/src/posix/poll.rs
@@ -29,7 +29,11 @@ fn wait_fd(fd: RawFd, events: PollFlags, timeout: Duration) -> io::Result<()> {
     #[cfg(target_os = "linux")]
     let wait_res = {
         let timespec = TimeSpec::milliseconds(milliseconds);
-        nix::poll::ppoll(slice::from_mut(&mut fd), Some(timespec), SigSet::empty())
+        nix::poll::ppoll(
+            slice::from_mut(&mut fd),
+            Some(timespec),
+            Some(SigSet::empty()),
+        )
     };
     #[cfg(not(target_os = "linux"))]
     let wait_res = nix::poll::poll(slice::from_mut(&mut fd), milliseconds as nix::libc::c_int);


### PR DESCRIPTION
Update to the latest [nix](https://github.com/nix-rust/nix) version [0.25.0](https://github.com/nix-rust/nix/releases/tag/v0.25.0) and adapt `nix::poll::ppoll` to receive an `Option<nix::sys::signal::SigSet>` instead of a plain `SigSet` (as introduced by https://github.com/nix-rust/nix/pull/1739).