### PR TITLE
Fix OpenBSD compilation issue caused by disabled ErrorKind "use"

### DIFF
--- a/src/posix/enumerate.rs
+++ b/src/posix/enumerate.rs
@@ -31,7 +31,8 @@ use crate::UsbPortInfo;
     target_os = "ios",
     all(target_os = "linux", not(target_env = "musl"), feature = "libudev"),
     target_os = "macos",
-    target_os = "netbsd"
+    target_os = "netbsd",
+    target_os = "openbsd",
 ))]
 use crate::{Error, ErrorKind};
 use crate::{Result, SerialPortInfo};


### PR DESCRIPTION
Compilation error seen in this block:

```rust
        /// Enumerating serial ports on this platform is not supported
        pub fn available_ports() -> Result<Vec<SerialPortInfo>> {
            Err(Error::new(
                ErrorKind::Unknown,
                "Not implemented for this OS",
            ))
        }
```