### PR TITLE
Update nix dependency

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,7 +56,7 @@ jobs:
       disable_tests: true
       extra_packages: libudev-dev
       target: x86_64-unknown-linux-gnu
-      toolchain: "1.46.0"
+      toolchain: "1.56.1"
 
   # --------------------------------------------------------------------------
   # BUILD

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["hardware-support"]
 [target."cfg(unix)".dependencies]
 bitflags = "1.3.2"
 cfg-if = "1.0.0"
-nix = { version = "0.25.0", default-features = false, features = ["fs", "ioctl", "poll", "signal", "term"] }
+nix = { version = "0.26", default-features = false, features = ["fs", "ioctl", "poll", "signal", "term"] }
 
 [target.'cfg(all(target_os = "linux", not(target_env = "musl")))'.dependencies]
 libudev = { version = "0.3.0", optional = true }

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ can help debug software or hardware errors.
 
 # Dependencies
 
-Rust versions 1.46.0 and higher are supported.
+Rust versions 1.56.1 and higher are supported.
 
 For GNU Linux `pkg-config` headers are required:
 


### PR DESCRIPTION
This PR updates [nix](https://github.com/nix-rust/nix) dependency to their latest version (0.25.0 => 0.26).

This update was without changes to the code.

This PR is a follow-up of https://github.com/serialport/serialport-rs/pull/72.

#### MSRV
Furthermore bump the MSRV to 1.56.1 as this is required by nix v0.26.0 (see https://github.com/nix-rust/nix/pull/1792). https://github.com/serialport/serialport-rs/commit/0a743546848cffd27da9851aea98980b18f05b95 reduced the MSRV because of a Yocto dependency. Currently following rust versions are used in the maintained yocto project versions:

- [master](https://git.yoctoproject.org/poky/tree/meta/recipes-devtools/rust?h=master): v1.65.0
- [langdale](https://git.yoctoproject.org/poky/tree/meta/recipes-devtools/rust?h=langdale): v1.63.0
- [kirkstone](https://git.yoctoproject.org/poky/tree/meta/recipes-devtools/rust?h=kirkstone): v1.59.0 (current LTS)
- dunfell: no rust support

Therefore this MSRV change (1.46.0 => 1.56.1) shouldn't have any effect on YoctoProject releases.