### PR TITLE
Update dev-dependecy clap to v4.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,7 +56,7 @@ jobs:
       disable_tests: true
       extra_packages: libudev-dev
       target: x86_64-unknown-linux-gnu
-      toolchain: "1.56.1"
+      toolchain: "1.60.0"
 
   # --------------------------------------------------------------------------
   # BUILD

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
     "Jesse Braham <jesse@beta7.io>",
 ]
 edition = "2018"
-rust-version = "1.56.1"
+rust-version = "1.60"
 description = "A cross-platform low-level serial port library."
 documentation = "https://docs.rs/serialport"
 repository = "https://github.com/serialport/serialport-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ features = [
 serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
-clap = { version = "3.1.6", features = ["derive"] }
+clap = { version = "4.0", features = ["derive"] }
 
 [features]
 default = ["libudev"]

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ can help debug software or hardware errors.
 # Dependencies
 
 Rust versions 1.56.1 and higher are supported.
+Rust versions 1.60.0 and higher are supported.
 
 For GNU/Linux `pkg-config` headers are required:
 

--- a/examples/clear_input_buffer.rs
+++ b/examples/clear_input_buffer.rs
@@ -59,8 +59,8 @@ fn main() {
              .required(true))
         .get_matches();
 
-    let port_name = matches.value_of("port").unwrap();
-    let baud_rate = matches.value_of("baud").unwrap();
+    let port_name = matches.get_one::<String>("port").unwrap();
+    let baud_rate = matches.get_one::<String>("baud").unwrap();
 
     let exit_code = match run(port_name, baud_rate) {
         Ok(_) => 0,

--- a/examples/clear_output_buffer.rs
+++ b/examples/clear_output_buffer.rs
@@ -21,7 +21,7 @@ use std::sync::mpsc;
 use std::thread;
 use std::time::Duration;
 
-use clap::{Arg, ArgMatches, Command};
+use clap::{Arg, Command};
 
 use serialport::ClearBuffer;
 
@@ -45,14 +45,14 @@ fn main() {
              .use_value_delimiter(false)
              .required(true))
         .arg(Arg::new("block-size")
-             .help(Some(block_size_help.as_str()))
+             .help(block_size_help)
              .use_value_delimiter(false)
              .default_value(DEFAULT_BLOCK_SIZE))
         .get_matches();
 
-    let port_name = matches.value_of("port").unwrap();
-    let baud_rate = matches.value_of("baud").unwrap();
-    let block_size = ArgMatches::value_of_t(&matches, "block-size").unwrap_or_else(|e| e.exit());
+    let port_name = matches.get_one::<String>("port").unwrap();
+    let baud_rate = matches.get_one::<String>("baud").unwrap();
+    let block_size = *matches.get_one::<usize>("block-size").unwrap();
 
     let exit_code = match run(port_name, baud_rate, block_size) {
         Ok(_) => 0,

--- a/examples/hardware_check.rs
+++ b/examples/hardware_check.rs
@@ -39,16 +39,16 @@ fn main() {
         .arg(Arg::new("loopback-port")
              .help("The device path of a second serial port that is connected to the first serial port. Mutually exclusive with the --loopback option.")
              .use_value_delimiter(false)
-             .takes_value(true)
+             .num_args(1)
              .long("loopback-port"))
         .get_matches();
 
-    let port1_name = matches.value_of("port").unwrap();
-    let port2_name = matches.value_of("loopback-port").unwrap_or("");
-    let port1_loopback = matches.is_present("loopback");
+    let port1_name = matches.get_one::<String>("port").unwrap();
+    let port2_name = matches.get_one::<String>("loopback-port");
+    let port1_loopback = matches.get_flag("loopback");
 
     // Loopback mode is only available when a single port is specified
-    if port1_loopback && !port2_name.is_empty() {
+    if port1_loopback && port2_name.is_some() {
         eprintln!("ERROR: loopback mode can only be enabled when a single port is specified.");
         ::std::process::exit(1);
     }
@@ -63,7 +63,7 @@ fn main() {
     };
     test_single_port(&mut *port1, port1_loopback);
 
-    if !port2_name.is_empty() {
+    if let Some(port2_name) = port2_name {
         // Run single-port tests on port2
         let mut port2 = match serialport::new(port2_name, 9600).open() {
             Err(e) => {

--- a/examples/receive_data.rs
+++ b/examples/receive_data.rs
@@ -18,12 +18,12 @@ fn main() {
                 .help("The baud rate to connect at")
                 .use_value_delimiter(false)
                 .required(true)
-                .validator(valid_baud),
+                .value_parser(valid_baud),
         )
         .get_matches();
 
-    let port_name = matches.value_of("port").unwrap();
-    let baud_rate = matches.value_of("baud").unwrap().parse::<u32>().unwrap();
+    let port_name = matches.get_one::<String>("port").unwrap();
+    let baud_rate = *matches.get_one::<u32>("baud").unwrap();
 
     let port = serialport::new(port_name, baud_rate)
         .timeout(Duration::from_millis(10))

--- a/examples/transmit.rs
+++ b/examples/transmit.rs
@@ -1,6 +1,7 @@
 use std::io::{self, Write};
 use std::time::Duration;
 
+use clap::builder::PossibleValuesParser;
 use clap::{Arg, Command};
 
 use serialport::{DataBits, StopBits};
@@ -19,54 +20,54 @@ fn main() {
                 .help("The baud rate to connect at")
                 .use_value_delimiter(false)
                 .required(true)
-                .validator(valid_baud),
+                .value_parser(valid_baud),
         )
         .arg(
             Arg::new("stop-bits")
                 .long("stop-bits")
                 .help("Number of stop bits to use")
-                .takes_value(true)
-                .possible_values(&["1", "2"])
+                .num_args(1)
+                .value_parser(PossibleValuesParser::new(["1", "2"]))
                 .default_value("1"),
         )
         .arg(
             Arg::new("data-bits")
                 .long("data-bits")
                 .help("Number of data bits to use")
-                .takes_value(true)
-                .possible_values(&["5", "6", "7", "8"])
+                .num_args(1)
+                .value_parser(PossibleValuesParser::new(["5", "6", "7", "8"]))
                 .default_value("8"),
         )
         .arg(
             Arg::new("rate")
                 .long("rate")
                 .help("Frequency (Hz) to repeat transmission of the pattern (0 indicates sending only once")
-                .takes_value(true)
+                .num_args(1)
                 .default_value("1"),
         )
         .arg(
             Arg::new("string")
                 .long("string")
                 .help("String to transmit")
-                .takes_value(true)
+                .num_args(1)
                 .default_value("."),
         )
         .get_matches();
 
-    let port_name = matches.value_of("port").unwrap();
-    let baud_rate = matches.value_of("baud").unwrap().parse::<u32>().unwrap();
-    let stop_bits = match matches.value_of("stop-bits") {
-        Some("2") => StopBits::Two,
+    let port_name = matches.get_one::<String>("port").unwrap();
+    let baud_rate = *matches.get_one::<u32>("baud").unwrap();
+    let stop_bits = match matches.get_one::<u32>("stop-bits") {
+        Some(2) => StopBits::Two,
         _ => StopBits::One,
     };
-    let data_bits = match matches.value_of("data-bits") {
-        Some("5") => DataBits::Five,
-        Some("6") => DataBits::Six,
-        Some("7") => DataBits::Seven,
+    let data_bits = match matches.get_one::<u32>("data-bits") {
+        Some(5) => DataBits::Five,
+        Some(6) => DataBits::Six,
+        Some(7) => DataBits::Seven,
         _ => DataBits::Eight,
     };
-    let rate = matches.value_of("rate").unwrap().parse::<u32>().unwrap();
-    let string = matches.value_of("string").unwrap();
+    let rate = *matches.get_one::<u32>("rate").unwrap();
+    let string = matches.get_one::<String>("string").unwrap();
 
     let builder = serialport::new(port_name, baud_rate)
         .stop_bits(stop_bits)


### PR DESCRIPTION
This PR updates [clap](https://github.com/clap-rs/clap) dependency to its latest version (3.1.6 => 4.0).

The clap update needed some changes in the code because of function deprecation in the [clap v3.2.0](https://github.com/clap-rs/clap/blob/master/CHANGELOG.md#320---2022-06-13) and [clap v4.0.0](https://github.com/clap-rs/clap/blob/master/CHANGELOG.md#400---2022-09-28) releases.

This PR is a follow-up of https://github.com/serialport/serialport-rs/pull/72.

#### MSRV
Furthermore bump the MSRV to 1.60.0 as this is required by clap v4.0.0 (see https://github.com/clap-rs/clap/pull/4060). https://github.com/serialport/serialport-rs/commit/0a743546848cffd27da9851aea98980b18f05b95 reduced the MSRV because of a Yocto dependency. Currently following rust versions are used in the maintained yocto project versions:

- [master](https://git.yoctoproject.org/poky/tree/meta/recipes-devtools/rust?h=master): v1.65.0
- [langdale](https://git.yoctoproject.org/poky/tree/meta/recipes-devtools/rust?h=langdale): v1.63.0
- [kirkstone](https://git.yoctoproject.org/poky/tree/meta/recipes-devtools/rust?h=kirkstone): v1.59.0 (current LTS)
- dunfell: no rust support

Therefore this MSRV change (1.46.0 => 1.60.0) will drop kirkstone support, which is the current LTS release, supported until April 2024 at least (according to https://wiki.yoctoproject.org/wiki/Releases).