### PR TITLE
query windows registry for all COM ports + `Modem` class devices

### DIFF
--- a/src/windows/enumerate.rs
+++ b/src/windows/enumerate.rs
@@ -459,7 +459,7 @@ pub fn available_ports() -> Result<Vec<SerialPortInfo>> {
             );
 
             // This technique also returns parallel ports, so we filter these out.
-            if !port_name.starts_with("COM") {
+            if port_name.starts_with("LPT") {
                 continue;
             }
 

--- a/src/windows/enumerate.rs
+++ b/src/windows/enumerate.rs
@@ -63,7 +63,7 @@ fn get_ports_guids() -> Result<Vec<GUID>> {
             else if len_cmp == std::cmp::Ordering::Greater {
                 guids.truncate(class_start_idx + num_guids as usize);
             }
-            break; // next guid
+            break; // next name
         }
     }
     Ok(guids)

--- a/src/windows/enumerate.rs
+++ b/src/windows/enumerate.rs
@@ -15,18 +15,18 @@ use winapi::um::winreg::*;
 
 use crate::{Error, ErrorKind, Result, SerialPortInfo, SerialPortType, UsbPortInfo};
 
-// According to the MSDN docs, we should use SetupDiGetClassDevs, SetupDiEnumDeviceInfo
-// and SetupDiGetDeviceInstanceId in order to enumerate devices.
-// https://msdn.microsoft.com/en-us/windows/hardware/drivers/install/enumerating-installed-devices
-//
-// SetupDiGetClassDevs returns the devices associated with a particular class of devices.
-// We want the list of devices which shows up in the Device Manager as "Ports (COM & LPT)"
-// which is otherwise known as the "Ports" class.
-//
-// get_pots_guids returns all of the classes (guids) associated with the name "Ports".
+/// According to the MSDN docs, we should use SetupDiGetClassDevs, SetupDiEnumDeviceInfo
+/// and SetupDiGetDeviceInstanceId in order to enumerate devices.
+/// https://msdn.microsoft.com/en-us/windows/hardware/drivers/install/enumerating-installed-devices
 fn get_ports_guids() -> Result<Vec<GUID>> {
-    // Note; unwrap can't fail, since names are valid UTF-8.
+    // SetupDiGetClassDevs returns the devices associated with a particular class of devices.
+    // We want the list of devices which are listed as COM ports (generally those that show up in the
+    // Device Manager as "Ports (COM & LPT)" which is otherwise known as the "Ports" class).
+    //
+    // The list of system defined classes can be found here:
+    // https://learn.microsoft.com/en-us/windows-hardware/drivers/install/system-defined-device-setup-classes-available-to-vendors
     let class_names = [
+        // Note; since names are valid UTF-8, unwrap can't fail
         CString::new("Ports").unwrap(),
         CString::new("Modem").unwrap(),
     ];

--- a/src/windows/enumerate.rs
+++ b/src/windows/enumerate.rs
@@ -100,7 +100,7 @@ fn parse_usb_port_info(hardware_id: &str, parent_hardware_id: Option<&str>) -> O
         .name("iid")
         .and_then(|m| u8::from_str_radix(m.as_str(), 16).ok());
 
-    if let Some(_) = interface {
+    if interface.is_some() {
         // If this is a composite device, we need to parse the parent's HWID to get the correct information.
         caps = re.captures(parent_hardware_id?)?;
     }

--- a/src/windows/enumerate.rs
+++ b/src/windows/enumerate.rs
@@ -471,16 +471,18 @@ pub fn available_ports() -> Result<Vec<SerialPortInfo>> {
     }
     // ports identified through the registry have no additional information
     let mut raw_ports_set = get_registry_com_ports();
-    // remove any duplicates. HashSet makes this relatively cheap
-    for port in ports.iter() {
-        raw_ports_set.remove(&port.port_name);
-    }
-    // add remaining ports as "unknown" type
-    for raw_port in raw_ports_set {
-        ports.push(SerialPortInfo {
-            port_name: raw_port,
-            port_type: SerialPortType::Unknown,
-        })
+    if raw_ports_set.len() > ports.len() {
+        // remove any duplicates. HashSet makes this relatively cheap
+        for port in ports.iter() {
+            raw_ports_set.remove(&port.port_name);
+        }
+        // add remaining ports as "unknown" type
+        for raw_port in raw_ports_set {
+            ports.push(SerialPortInfo {
+                port_name: raw_port,
+                port_type: SerialPortType::Unknown,
+            })
+        }
     }
     Ok(ports)
 }

--- a/src/windows/enumerate.rs
+++ b/src/windows/enumerate.rs
@@ -459,7 +459,7 @@ pub fn available_ports() -> Result<Vec<SerialPortInfo>> {
             );
 
             // This technique also returns parallel ports, so we filter these out.
-            if port_name.starts_with("LPT") {
+            if !port_name.starts_with("COM") {
                 continue;
             }
 


### PR DESCRIPTION
As noted in #81 the list of ports returned from `serialport::available_ports` in windows is incomplete when using v4.2.0. ~~This PR does the bare minimum to present a complete list~~

The easiest way to get the full list (to my knowledge) is to query the registry, although that gives basically zero information about the additional keys ~~and as such this PR adds the ports with type "Unknown". This at least makes those ports visible through "available ports"~~. To my understanding, the device driver can choose which category it comes under causing the generic "ports" category to be incomplete for certain devices.

~~Future work would involve digging up more information about these "unknown" ports including the "human" name visible in device manager~~

EDIT

This now resolves #81 
The additional commits ([9e7791a14df3193494ccbd82f25de872f9d7dbd2..c3bf38bba9b4166aeeb7bab29872d6c916bd880d](https://github.com/serialport/serialport-rs/pull/84/files/49b67891f0d9aa97da0df55f49c876d1f8e0363e..c3bf38bba9b4166aeeb7bab29872d6c916bd880d)) refactor `get_ports_guids` to also get the guids for `Modem` class devices

Filtering of devices returned by iterating has been inverted (`!name.starts_with("COM")` instead of the previous `name.starts_with("LPT")`) because there is potentially more than LPT devices to filter out

COM ports that don't belong to either of these categories will still be added to the "unknown" list ensuring that the list of available ports is always complete, even if missing detailed information