### PR TITLE
Windows unicode (`_W`) api for all Win32 functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ project adheres to [Semantic Versioning](https://semver.org/).
   `available_ports` on Windows. This is now done by some bespoke code to
   significantly reduce build times.
   [#201](https://github.com/serialport/serialport-rs/pull/201)
+* Switch from ANSI to Unicode/UTF-16 string API on Windows.
+   [#89](https://github.com/serialport/serialport-rs/pull/89)
 ### Fixed
 * Fix looking up `UsbPortInfo::interface` on macOS.
   [#193](https://github.com/serialport/serialport-rs/pull/193)

--- a/src/windows/enumerate.rs
+++ b/src/windows/enumerate.rs
@@ -567,6 +567,26 @@ mod test {
 
     use quickcheck_macros::quickcheck;
 
+    #[test]
+    fn from_utf16_lossy_trimmed_trimming_empty() {
+        assert_eq!("", from_utf16_lossy_trimmed(&[]));
+        assert_eq!("", from_utf16_lossy_trimmed(&[0]));
+    }
+
+    #[test]
+    fn from_utf16_lossy_trimmed_trimming() {
+        let test_str = "Testing";
+        let wtest_str: Vec<u16> = as_utf16(test_str);
+        let wtest_str_trailing = wtest_str
+            .iter()
+            .copied()
+            .chain([0, 0, 0, 0]) // add some null chars
+            .collect::<Vec<_>>();
+        let and_back = from_utf16_lossy_trimmed(&wtest_str_trailing);
+
+        assert_eq!(test_str, and_back);
+    }
+
     // Check that passing some random data to HwidMatches::new() does not cause a panic.
     #[quickcheck]
     fn quickcheck_hwidmatches_new_does_not_panic_from_random_input(hwid: String) -> bool {
@@ -740,18 +760,4 @@ mod test {
         let info = parse_usb_port_info(unicode_serial, None).unwrap();
         assert_eq!(info.serial_number.as_deref(), Some("3854356β"));
     }
-}
-
-#[test]
-fn encoding_trimming_utf16() {
-    let test_str = "Testing";
-    let wtest_str: Vec<u16> = as_utf16(test_str);
-    let wtest_str_trailing = wtest_str
-        .iter()
-        .copied()
-        .chain([0, 0, 0, 0]) // add some null chars
-        .collect::<Vec<_>>();
-    let and_back = from_utf16_lossy_trimmed(&wtest_str_trailing);
-
-    assert_eq!(test_str, and_back);
 }

--- a/src/windows/enumerate.rs
+++ b/src/windows/enumerate.rs
@@ -7,7 +7,6 @@ use winapi::shared::minwindef::*;
 use winapi::shared::winerror::*;
 use winapi::um::cfgmgr32::*;
 use winapi::um::cguid::GUID_NULL;
-use winapi::um::errhandlingapi::GetLastError;
 use winapi::um::setupapi::*;
 use winapi::um::winnt::{KEY_READ, REG_SZ};
 use winapi::um::winreg::*;
@@ -409,7 +408,7 @@ impl PortDevice {
             )
         };
 
-        if res == FALSE && unsafe { GetLastError() } != ERROR_INSUFFICIENT_BUFFER {
+        if res == FALSE {
             return None;
         }
 

--- a/src/windows/enumerate.rs
+++ b/src/windows/enumerate.rs
@@ -394,6 +394,7 @@ impl PortDevice {
     // Retrieves a device property and returns it, if it exists. Returns None if the property
     // doesn't exist.
     fn property(&mut self, property_id: DWORD) -> Option<String> {
+        let mut value_type = 0;
         let mut property_buf = [0u16; MAX_PATH];
 
         let res = unsafe {
@@ -401,14 +402,14 @@ impl PortDevice {
                 self.hdi,
                 &mut self.devinfo_data,
                 property_id,
-                ptr::null_mut(),
+                &mut value_type,
                 property_buf.as_mut_ptr() as PBYTE,
                 property_buf.len() as DWORD,
                 ptr::null_mut(),
             )
         };
 
-        if res == FALSE {
+        if res == FALSE || value_type != REG_SZ {
             return None;
         }
 

--- a/src/windows/enumerate.rs
+++ b/src/windows/enumerate.rs
@@ -493,7 +493,7 @@ fn get_registry_com_ports() -> HashSet<String> {
                 };
                 if FAILED(res)
                     || value_type != REG_SZ // only valid for text values
-                    || byte_len % 2 != 0 // out byte len should be a multiple of char size
+                    || byte_len % 2 != 0 // out byte len should be a multiple of u16 size
                     || byte_len > buffer_byte_len
                 {
                     break;

--- a/src/windows/enumerate.rs
+++ b/src/windows/enumerate.rs
@@ -474,8 +474,7 @@ fn get_registry_com_ports() -> HashSet<String> {
                 let mut val_name_buff = [0u16; MAX_PATH];
                 let mut val_name_size = MAX_PATH as u32;
                 let mut value_type = 0;
-                // if 100 chars is not enough for COM<number> something is very wrong
-                let mut val_data = [0u16; 100];
+                let mut val_data = [0u16; MAX_PATH];
                 let buffer_byte_len = 2 * val_data.len() as DWORD; // len doubled
                 let mut byte_len = buffer_byte_len;
 

--- a/src/windows/enumerate.rs
+++ b/src/windows/enumerate.rs
@@ -348,7 +348,7 @@ impl PortDevice {
         // https://learn.microsoft.com/en-us/windows/win32/api/winreg/nf-winreg-regqueryvalueexw
         let mut port_name_buffer = [0u16; MAX_PATH];
         let mut buffer_byte_len = 2 * port_name_buffer.len() as DWORD;
-        let mut key_type: DWORD = 0;
+        let mut value_type = 0;
 
         let value_name = as_utf16("PortName");
         let err = unsafe {
@@ -356,7 +356,7 @@ impl PortDevice {
                 hkey,
                 value_name.as_ptr(),
                 ptr::null_mut(),
-                &mut key_type,
+                &mut value_type,
                 port_name_buffer.as_mut_ptr() as *mut u8,
                 &mut buffer_byte_len,
             )
@@ -367,7 +367,7 @@ impl PortDevice {
             return String::new();
         }
         // https://learn.microsoft.com/en-us/windows/win32/sysinfo/registry-value-types
-        let value_is_text = key_type == REG_SZ;
+        let value_is_text = value_type == REG_SZ;
         if !value_is_text || buffer_byte_len % 2 != 0 {
             // read something but it wasn't the expected registry type
             return String::new();

--- a/src/windows/enumerate.rs
+++ b/src/windows/enumerate.rs
@@ -477,6 +477,7 @@ fn get_registry_com_ports() -> HashSet<String> {
                 // if 100 chars is not enough for COM<number> something is very wrong
                 let mut val_data = [0u16; 100];
                 let mut byte_len = 2 * val_data.len() as u32; // len doubled
+                let buffer_byte_len = byte_len;
 
                 // SAFETY: ffi, all inputs are correct
                 let res = unsafe {
@@ -491,7 +492,11 @@ fn get_registry_com_ports() -> HashSet<String> {
                         &mut byte_len,
                     )
                 };
-                if FAILED(res) || val_data.len() < byte_len as usize {
+                if FAILED(res)
+                    || value_type != REG_SZ // only valid for text values
+                    || byte_len % 2 != 0 // out byte len should be a multiple of char size
+                    || buffer_byte_len < byte_len
+                {
                     break;
                 }
                 // key data is returned as u16


### PR DESCRIPTION
Based on #84.
[The new changes](https://github.com/serialport/serialport-rs/pull/89/files/a1c13f5608a15c6107c97ff2445dbe6df06e8611..397a5f72aeda475e9997c9d7304451af815562c8)

> We should probably be using the unicode (`SetupDiClassGuidsFromNameW`) or automatic (`SetupDiClassGuidsFromName`) versions of all windows functions. Otherwise devices from non-english speaking manufacturers or users in different localities may run into issues getting correct device names and information.
> 
> See: https://learn.microsoft.com/en-us/windows/win32/intl/unicode-in-the-windows-api

_Originally posted by @mlsvrts in https://github.com/serialport/serialport-rs/pull/84#discussion_r1148426835_

> In that case, I think updating these in another PR instead of putting additional changes here makes more sense to me!

_Originally posted by @mlsvrts in https://github.com/serialport/serialport-rs/pull/84#discussion_r1148673211_
            