### PR TITLE
Fix memory leaks on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 ### Changed
 ### Fixed
+* A number of memory leaks have been addressed when using serialport-rs on
+macOS. In particular, enumerating USB ports and not discovering any could
+quickly consume 1GiB of memory in a minute or so. More generally, if you are using serialport-rs
+on macOS then please upgrade to this version as soon as possible.
 ### Removed
 
 ## [4.2.0] - 2022-06-02

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ features = [
 ]
 
 [dependencies]
+scopeguard = "1.1"
 serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
There are a number of memory leaks on macOS, particularly when performing the "available_ports" method.

I've added a dependency on `scopeguard` so that we can manage deallocations with a little more sanity. I've also validated that the leaks are repaired via XCode's Instruments.