### PR TITLE
Maintenance release 4.2.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,6 +59,26 @@ jobs:
       toolchain: "1.56.1"
 
   # --------------------------------------------------------------------------
+  # cargo-deny
+
+  cargo-deny:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        checks:
+          - advisories
+          - bans licenses sources
+
+    # Prevent sudden announcement of a new advisory from failing ci:
+    continue-on-error: ${{ matrix.checks == 'advisories' }}
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: EmbarkStudios/cargo-deny-action@v1
+      with:
+        command: check ${{ matrix.checks }}
+
+  # --------------------------------------------------------------------------
   # BUILD
 
   aarch64-apple-darwin:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,7 +56,7 @@ jobs:
       disable_tests: true
       extra_packages: libudev-dev
       target: x86_64-unknown-linux-gnu
-      toolchain: "1.46.0"
+      toolchain: "1.56.1"
 
   # --------------------------------------------------------------------------
   # BUILD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 ### Changed
 ### Fixed
+* A number of memory leaks have been addressed when using serialport-rs on
+macOS. In particular, enumerating USB ports and not discovering any could
+quickly consume 1GiB of memory in a minute or so. More generally, if you are using serialport-rs
+on macOS then please upgrade to this version as soon as possible.
 ### Removed
 
 ## [4.2.0] - 2022-06-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](http://keepachangelog.com/)
-and this project adheres to [Semantic Versioning](http://semver.org/).
+The format is based on [Keep a Changelog](https://keepachangelog.com/) and this
+project adheres to [Semantic Versioning](https://semver.org/).
 
 ## UNRELEASED
 ### Added
@@ -32,8 +32,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [4.1.0] - 2022-04-04
 ### Added
-* impl `SerialPort` for `&mut T`. This allows a `&mut T (where T: SerialPort)` to be used in a
-  context where `impl SerialPort` is expected.
+* impl `SerialPort` for `&mut T`. This allows a `&mut T (where T: SerialPort)`
+  to be used in a context where `impl SerialPort` is expected.
   [!114](https://gitlab.com/susurrus/serialport-rs/-/merge_requests/114)
 ### Changed
 * Updated `nix` dependency to 0.23.1.
@@ -54,40 +54,45 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 * Update maintenance status to looking for a new maintainer.
 ### Fixed
-* Properly initialize DCB structure on Windows. This fixes some non-functional devices.
+* Properly initialize DCB structure on Windows. This fixes some non-functional
+  devices.
   [!97](https://gitlab.com/susurrus/serialport-rs/-/merge_requests/97)
 ### Removed
 
 ## [4.0.0] - 2020-12-17
 ### Added
-* Added `send_break()` to `TTYPort`
+* Added `send_break()` to `TTYPort`.
   [!69](https://gitlab.com/susurrus/serialport-rs/merge_requests/69)
-* Enable `available_ports()` for Linux musl targets and those without the `libudev`
-  feature enabled by scanning `/sys/` for ports.
+* Enable `available_ports()` for Linux musl targets and those without the
+  `libudev` feature enabled by scanning `/sys/` for ports.
   [!72](https://gitlab.com/susurrus/serialport-rs/merge_requests/72)
-* `ENOENT` and `EACCES` errors are now exposed as `NotFound` and `PermissionDenied` errors on Linux
+* `ENOENT` and `EACCES` errors are now exposed as `NotFound` and
+  `PermissionDenied` errors on Linux.
   [!80](https://gitlab.com/susurrus/serialport-rs/merge_requests/80)
-* `try_clone_native()` was added to `COMPort` and `TTYPort` to complement `SerialPort::try_clone()`
-  but returning the concrete type instead.
+* `try_clone_native()` was added to `COMPort` and `TTYPort` to complement
+  `SerialPort::try_clone()` but returning the concrete type instead.
   [!85](https://gitlab.com/susurrus/serialport-rs/merge_requests/85)
-* Added `set_break()` and `clear_break()` to `SerialPort`
+* Added `set_break()` and `clear_break()` to `SerialPort`.
   [!70](https://gitlab.com/susurrus/serialport-rs/merge_requests/70)
 
 ### Changed
-* Minimum supported Rust version is now 1.36.0 to support the `mem::MaybeUninit` feature.
-* The platform-specific `TTYPort`/`BreakDuration` and `COMPort` are now at the root level rather
-  than under the `posix` and `windows` submodules respectively.
-* Opening `SerialPort` s now uses the builder pattern through `serialport::new()`. See the
-  README for concrete examples.
+* Minimum supported Rust version is now 1.36.0 to support the `mem::MaybeUninit`
+  feature.
+* The platform-specific `TTYPort`/`BreakDuration` and `COMPort` are now at the
+  root level rather than under the `posix` and `windows` submodules
+  respectively.
+* Opening `SerialPort` s now uses the builder pattern through
+  `serialport::new()`. See the README for concrete examples.
   [!73](https://gitlab.com/susurrus/serialport-rs/merge_requests/73)
-* `SerialPorts` s are no longer opened with a default timeout of 1ms
-* Under linux, the `manufacturer` and `product` fields of `UsbPortInfo` now take their values from
-  the `ID_VENDOR_FROM_DATABASE` and `ID_MODEL_FROM_DATABASE` udev properties respectively, instead
-  of the `ID_VENDOR` and `ID_MODEL` properties that were used before. When the `_FROM_DATABASE`
-  values are not available, it falls back to the old behavior.
+* `SerialPorts`s are no longer opened with a default timeout of 1ms.
+* Under linux, the `manufacturer` and `product` fields of `UsbPortInfo` now take
+  their values from the `ID_VENDOR_FROM_DATABASE` and `ID_MODEL_FROM_DATABASE`
+  udev properties respectively, instead of the `ID_VENDOR` and `ID_MODEL`
+  properties that were used before. When the `_FROM_DATABASE` values are not
+  available, it falls back to the old behavior.
   [!86](https://gitlab.com/susurrus/serialport-rs/merge_requests/86)
-* POSIX ports are no longer opened in exclusive mode. After opening they can be made exclusive via
-  `TTYPort::set_exclusive()`.
+* POSIX ports are no longer opened in exclusive mode. After opening they can be
+  made exclusive via `TTYPort::set_exclusive()`.
   [!98](https://gitlab.com/susurrus/serialport-rs/merge_requests/98)
 
 ### Fixed
@@ -103,13 +108,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [3.3.0] - 2019-06-12
 ### Added
-* Added support for arbitrary baud rates on Mac OS X and iOS
+* Added support for arbitrary baud rates on macOS and iOS.
 
 ### Changed
-* Minimum supported Rust version is now 1.31 to support using the 2018 edition of Rust.
+* Minimum supported Rust version is now 1.31 to support using the 2018 edition
+  of Rust.
 
 ### Fixed
-* Upgraded `sparc64-unknown-linux-gnu` to Tier 2 support
+* Upgraded `sparc64-unknown-linux-gnu` to Tier 2 support.
 
 ### Removed
 
@@ -118,11 +124,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Port enumeration is now supported on FreeBSD.
 
 ### Changed
-* Minimum supported Rust version changed to 1.24.1
-* Made `aarch64-unknown-linux-musl` a Tier-2 supported target
+* Minimum supported Rust version changed to 1.24.1.
+* Made `aarch64-unknown-linux-musl` a Tier-2 supported target.
 
 ### Fixed
-* Fixed software flow control for POSIX systems ([!54](https://gitlab.com/susurrus/serialport-rs/merge_requests/54))
+* Fixed software flow control for POSIX systems.
+  [!54](https://gitlab.com/susurrus/serialport-rs/merge_requests/54)
 
 ### Removed
 * Removed support for `x86_64-unknown-linux-gnux32`.
@@ -138,7 +145,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [3.0.0] - 2018-07-14
 ### Added
 * Arbitrary baud rates are now supported on BSDs, Linux, and Windows.
-* Added Tier 1 support for `{i586|i686|x86_64}-unknown-linux-musl`
+* Added Tier 1 support for `{i586|i686|x86_64}-unknown-linux-musl`.
 * Added Tier 2 support for:
   * `{arm|armv7}-linux-androideabi`
   * `i686-linux-android`
@@ -161,16 +168,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Renamed `SerialPort::port_name()` to `name()`.
 
 ### Fixed
-* On Windows, the `port_name` field on `SerialPortInfo` included an extraneous trailing nul byte
-  character.
+* On Windows, the `port_name` field on `SerialPortInfo` included an extraneous
+  trailing nul byte character.
 
 ### Removed
 * The `BaudRate` enum was removed in favor of a `u32`.
 
 ## [2.3.0] - 2018-03-13
 ### Added
-* Added `examples/hardware_check.rs` for use in debugging library or
-  driver issues when using physical serial ports.
+* Added `examples/hardware_check.rs` for use in debugging library or driver
+  issues when using physical serial ports.
 * Added `SerialPort::try_clone` which allows for cloning a port for full-duplex
   reading and writing.
 
@@ -183,126 +190,126 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   `SerialPort::try_clone` interface to work as people expect.
 
 ### Fixed
-* `TTYPort::into_raw_fd` will now work as expected. It previously closed
-  the port so the returned file descriptor would be invalid.
+* `TTYPort::into_raw_fd` will now work as expected. It previously closed the
+  port so the returned file descriptor would be invalid.
 * 921600 baud is now supported on NetBSD and FreeBSD.
 
 ## 2.2.0 - 2018-03-13
-Unreleased, happened due to a user error using `cargo-release`
+Unreleased, happened due to a user error using `cargo-release`.
 
 ## [2.1.0] - 2018-02-14
 ### Added
-* `impl FromRawHandle` for `COMPort`
+* `impl FromRawHandle` for `COMPort`.
 
 ### Changed
-* Specific IO-related errors are now returned instead of mapping every IO
-  error to Unknown. This makes it possible to catch things like time-out
-  errors.
+* Specific IO-related errors are now returned instead of mapping every IO error
+  to Unknown. This makes it possible to catch things like time-out errors.
 * Changed all baud rates to be reported as the discrete `BaudRate::Baud*` types
   rather than as the `BaudRate::BaudOther(*)` type.
 
 ### Fixed
-* Modem-type USB serial devices are now enumerated on OS X. This now allows
+* Modem-type USB serial devices are now enumerated on macOS. This now allows
   connected Arduinos to be detected.
 * Compilation on FreeBSD and NetBSD was fixed by removing the 921600 baud rates.
   These will be re-added in a future release.
 
 ## [2.0.0] - 2017-12-18
 ### Added
-* USB device information is now returned in calls to `available_ports()`
-* Serial port enumeration is now supported on Mac
-* Serial port enumeration now attempts to return the interface used for the
-  port (USB, PCI, Bluetooth, Unknown).
+* USB device information is now returned in calls to `available_ports()`.
+* Serial port enumeration is now supported on Mac.
+* Serial port enumeration now attempts to return the interface used for the port
+  (USB, PCI, Bluetooth, Unknown).
 * `BaudRate::standard_rates()` provides a vector of cross-platform baud rates.
-* `SerialPort` trait is now `Send`
+* `SerialPort` trait is now `Send`.
 
 ### Changed
-* Software license has changed from LGPLv3+ to MPL-2.0. This makes it
-  possible to use this library in any Rust project if it's unmodified.
-* Mac is now a Tier 2 supported platform
+* Software license has changed from LGPLv3+ to MPL-2.0. This makes it possible
+  to use this library in any Rust project if it's unmodified.
+* Mac is now a Tier 2 supported platform.
 * Removed `BaudRate::from_speed(usize)` and `BaudRate::speed -> usize` in favor
   of the `From<u32>` and `Into<u32>` traits.
 * Removed `available_baud_rates` in favor of `BaudRate::platform_rates()` as
-  this has a more clear semantic meaning. The returned list of baud rates is
-  now also correct for all supported platforms.
+  this has a more clear semantic meaning. The returned list of baud rates is now
+  also correct for all supported platforms.
 * Removed `termios` dependency in favor of `nix`. This is a big step towards
   supporting additional platforms.
 
 ### Fixed
 * Stop bits are now specified properly (had been reversed). Thanks to
-  @serviushack (MR#9)
+  @serviushack. (MR#9)
 * `TTYPort::pair()` is now thread-safe.
 * `TTYPort::open()` no longer leaks file descriptors if it errors. Thanks to
-  @daniel (MR#12)
-* Fixed compilation when targeting Android
+  @daniel. (MR#12)
+* Fixed compilation when targeting Android.
 
 ## [1.0.1] - 2017-02-20
 ### Fixed
-* `read()` now properly blocks for at least one character
-* Compilation now works on Mac
+* `read()` now properly blocks for at least one character.
+* Compilation now works on Mac.
 
 ## [1.0.0] - 2017-02-13
 ### Changed
-* Various documentation/README updates
-* Minor formatting fixes (from rustfmt)
+* Various documentation/README updates.
+* Minor formatting fixes (from rustfmt).
 
 ### Fixed
-* Platform-specific examples are now only built on appropriate platforms
+* Platform-specific examples are now only built on appropriate platforms.
 
 ## [0.9.0] - 2017-02-09
 ### Added
-* `impl Debug` for `COMPort`
-* `exclusive()` and `set_exclusive()` for `TTYPort`
-* `port_name()` for `SerialPort`
-* `impl FromRawFd` and `impl IntoRawFd` for `TTYPort`
-* `pair()` for `TTYPort`
+* `impl Debug` for `COMPort`.
+* `exclusive()` and `set_exclusive()` for `TTYPort`.
+* `port_name()` for `SerialPort`.
+* `impl FromRawFd` and `impl IntoRawFd` for `TTYPort`.
+* `pair()` for `TTYPort`.
 
 ## [0.3.0] - 2017-01-28
 ### Added
-* `open_with_settings()` to support initializing the port with custom settings
+* `open_with_settings()` to support initializing the port with custom settings.
 * `SerialPortSettings` is now publically usable being exported in the prelude,
   having all public and commented fields, and a `Default` impl.
 
 ### Changed
 * `TTYPort/COMPort::open()` now take a `SerialPortSettings` argument and return
-  concrete types
-* `serialport::open()` now initializes the port to reasonable defaults
-* Removed all instances of `try!()` for `?`
-* `SerialPort::set_all()` now borrows `SerialPortSettings`
+  concrete types.
+* `serialport::open()` now initializes the port to reasonable defaults.
+* Removed all instances of `try!()` for `?`.
+* `SerialPort::set_all()` now borrows `SerialPortSettings`.
 
 ## [0.2.4] - 2017-01-26
 ### Added
-* Report an Unimplemented error for unsupported unix targets
+* Report an Unimplemented error for unsupported unix targets.
 
 ### Changed
-* Minor changes suggested by Clippy
-* Reworked Cargo.toml to more easily support additional targets
+* Minor changes suggested by Clippy.
+* Reworked Cargo.toml to more easily support additional targets.
 
 ### Fixed
-* AppVeyor badge should now be properly displayed
+* AppVeyor badge should now be properly displayed.
 
 ## [0.2.3] - 2017-01-21
 ### Added
-* Specify AppVeyor build status badge for crates.io
+* Specify AppVeyor build status badge for crates.io.
 
 ## [0.2.2] - 2017-01-21
-* No changes, purely a version increment to push new crate metadata to crates.io
+* No changes, purely a version increment to push new crate metadata to
+  crates.io.
 
 ## [0.2.1] - 2017-01-21
 ### Added
-* Specify category for crates.io
+* Specify category for crates.io.
 
 ## [0.2.0] - 2017-01-07
 ### Added
-* Added a changelog
-* Added a getter/setter pair for all settings at once
-* An error is thrown if settings weren't correctly applied on POSIX
+* Added a changelog.
+* Added a getter/setter pair for all settings at once.
+* An error is thrown if settings weren't correctly applied on POSIX.
 
 ## [0.1.1] - 2016-12-23
 ### Changed
-* Fixed compilation on x86_64-pc-windows-gnu target
-* Added contributors to README
-* Clarified license terms in the README
+* Fixed compilation on x86_64-pc-windows-gnu target.
+* Added contributors to README.
+* Clarified license terms in the README.
 
 ## [0.1.0] - 2016-12-22
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,29 @@ project adheres to [Semantic Versioning](https://semver.org/).
 
 ## UNRELEASED
 ### Added
+* Add example for loopback testing with real hardware.
+  [#69](https://github.com/serialport/serialport-rs/pull/69)
+* Implement `fmt::Debug` and `fmt::Display` for `SerialPort` and related enums.
+  [#91](https://github.com/serialport/serialport-rs/pull/91)
 ### Changed
+* Migrated from unmaintainted dependency `mach` to `mach2`.
+* Update dependency `nix` from 0.24.1 to 0.26.0 and raise MSRV to 1.56.1.
+  [#67](https://github.com/serialport/serialport-rs/pull/67),
+  [#75](https://github.com/serialport/serialport-rs/pull/75),
+  [#78](https://github.com/serialport/serialport-rs/pull/78)
 ### Fixed
-* A number of memory leaks have been addressed when using serialport-rs on
-macOS. In particular, enumerating USB ports and not discovering any could
-quickly consume 1GiB of memory in a minute or so. More generally, if you are using serialport-rs
-on macOS then please upgrade to this version as soon as possible.
+* Skip attempts to set baud rate 0 on macOS.
+  [#58](https://github.com/serialport/serialport-rs/pull/58)
+* Fix getting actual result value from `tiocmget`.
+  [#61](https://github.com/serialport/serialport-rs/pull/61/files)
+* Fix serial number retrieval procedure on macOS.
+  [#65](https://github.com/serialport/serialport-rs/pull/65)
+* Fix port name retrieval procedure for Unicode names on Windows.
+  [#63](https://github.com/serialport/serialport-rs/pull/63)
+* Fix compilation for OpenBSD due to missing use declaration.
+  [#68](https://github.com/serialport/serialport-rs/pull/68)
+* A number of memory leaks have been addressed when using serialport-rs.
+  [#98](https://github.com/serialport/serialport-rs/pull/98)
 ### Removed
 
 ## [4.2.0] - 2022-06-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/) and this
 project adheres to [Semantic Versioning](https://semver.org/).
 
-## UNRELEASED
+## [Unreleased]
+### Added
+### Changed
+### Fixed
+### Removed
+
+## [4.2.1] - 2023-05-15
 ### Added
 * Add example for loopback testing with real hardware.
   [#69](https://github.com/serialport/serialport-rs/pull/69)
@@ -337,6 +343,8 @@ Unreleased, happened due to a user error using `cargo-release`.
 * Initial release.
 
 
+[Unreleased]: https://github.com/serialport/serialport-rs/compare/v4.2.1...HEAD
+[4.2.1]: https://github.com/serialport/serialport-rs/compare/v4.2.1...v4.2.1
 [4.2.0]: https://github.com/serialport/serialport-rs/compare/v4.1.0...v4.2.0
 [4.1.0]: https://github.com/serialport/serialport-rs/compare/v4.0.1...v4.1.0
 [4.0.1]: https://github.com/serialport/serialport-rs/compare/v4.0.0...v4.0.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["serial", "hardware", "system", "RS232"]
 categories = ["hardware-support"]
 
 [target."cfg(unix)".dependencies]
-bitflags = "1.3.2"
+bitflags = ">=1.3.1, <2.1.0"
 cfg-if = "1.0.0"
 nix = { version = "0.26", default-features = false, features = ["fs", "ioctl", "poll", "signal", "term"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ features = [
 serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
-clap = "3.1.6"
+clap = { version = "3.1.6", features = ["derive"] }
 
 [features]
 default = ["libudev"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["hardware-support"]
 [target."cfg(unix)".dependencies]
 bitflags = "1.3.2"
 cfg-if = "1.0.0"
-nix = { version = "0.25.0", default-features = false, features = ["fs", "ioctl", "poll", "signal", "term"] }
+nix = { version = "0.26", default-features = false, features = ["fs", "ioctl", "poll", "signal", "term"] }
 
 [target.'cfg(all(target_os = "linux", not(target_env = "musl")))'.dependencies]
 libudev = { version = "0.3.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,9 @@ authors = [
     "Jesse Braham <jesse@beta7.io>",
 ]
 edition = "2018"
-rust-version = "1.46"
-description = "A cross-platform low-level serial port library"
-documentation = "https://docs.rs/serialport/"
+rust-version = "1.56.1"
+description = "A cross-platform low-level serial port library."
+documentation = "https://docs.rs/serialport"
 repository = "https://github.com/serialport/serialport-rs"
 license = "MPL-2.0"
 keywords = ["serial", "hardware", "system", "RS232"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ features = [
 ]
 
 [dependencies]
+scopeguard = "1.1"
 serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serialport"
-version = "4.2.1-alpha.0"
+version = "4.2.1"
 authors = [
     "Bryant Mairs <bryant@mai.rs>",
     "Jesse Braham <jesse@beta7.io>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["hardware-support"]
 [target."cfg(unix)".dependencies]
 bitflags = "1.3.2"
 cfg-if = "1.0.0"
-nix = { version = "0.24.1", default-features = false, features = ["fs", "ioctl", "poll", "signal", "term"] }
+nix = { version = "0.25.0", default-features = false, features = ["fs", "ioctl", "poll", "signal", "term"] }
 
 [target.'cfg(all(target_os = "linux", not(target_env = "musl")))'.dependencies]
 libudev = { version = "0.3.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serialport"
-version = "4.2.1"
+version = "4.2.2-alpha.0"
 authors = [
     "Bryant Mairs <bryant@mai.rs>",
     "Jesse Braham <jesse@beta7.io>",

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,8 +1,8 @@
-# Mac OS X / iOS
+# macOS / iOS
 
 Macs use the usual `termios` TTY implementation that other POSIXes use, but support non-standard
-baud rates through the `iossiospeed` ioctl (as of OS X 10.4). To support non-standard baud rates on
-Mac, there are three main approaches:
+baud rates through the `iossiospeed` ioctl (as of Mac OS X 10.4). To support non-standard baud rates
+on Mac, there are three main approaches:
 
  1. Always use `iossiospeed`
  2. Use `iossiospeed` for non-standard bauds, but `termios` with standard bauds
@@ -10,7 +10,7 @@ Mac, there are three main approaches:
 
 ## Implementation notes
 
-This library uses the first approach. Given that OS X as far back as 10.4 supports it (2005), there
+This library uses the first approach. Given that macOS as far back as 10.4 supports it (2005), there
 seem to be no downsides. Internally, baud rates within the `termios` struct are kept at 9600 when
 that struct is read & written. This means that anytime the `termios` struct is written back (using
 `tcsetattr` a call to `iossiospeed` follows it. Additionally, the `termios` struct is not cached and
@@ -21,7 +21,8 @@ state can always be considered the canonical source.
 ## Platform notes
 
 `iossiospeed` has no official documentation that can be found by searching
-https://developer.apple.com. However [IOSerialTestLib.c](https://opensource.apple.com/source/IOSerialFamily/IOSerialFamily-93/tests/IOSerialTestLib.c.auto.html)
+https://developer.apple.com. However
+[IOSerialTestLib.c](https://opensource.apple.com/source/IOSerialFamily/IOSerialFamily-93/tests/IOSerialTestLib.c.auto.html)
 can be found on Apple's open source code repository and has some example code for using this API.
 
 Experimentation has shown that there are a few key features to using `iossiospeed`:
@@ -39,7 +40,7 @@ Experimentation has shown that there are a few key features to using `iossiospee
 ## Reference implementations
 
  * [picocom](https://github.com/npat-efault/picocom) follows the second approach. However they also
-cache the existing `termios` struct.
+   cache the existing `termios` struct.
 
 # Additional References
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,18 @@
 [![crates.io version badge](https://img.shields.io/crates/v/serialport.svg)](https://crates.io/crates/serialport)
-[![Documentation](https://docs.rs/serialport/badge.svg)](https://docs.rs/crate/serialport)
-![GitHub Workflow Status](https://img.shields.io/github/workflow/status/serialport/serialport-rs/CI?label=CI&logo=github&style=flat-square)
+[![Documentation](https://docs.rs/serialport/badge.svg)](https://docs.rs/serialport)
+[![GitHub workflow status](https://img.shields.io/github/actions/workflow/status/serialport/serialport-rs/ci.yaml?branch=main&logo=github)](https://github.com/serialport/serialport-rs/actions)
 
-> **Note:** This is a fork of the original [serialport-rs](https://gitlab.com/susurrus/serialport-rs) project on GitLab. Please note there have been some changes to both the supported targets and which Tier some targets are in, and there may be further changes to this made. Additionally, all relevant issues have been migrated to this repository.
+> **Note:** This is a fork of the original
+[serialport-rs](https://gitlab.com/susurrus/serialport-rs) project on GitLab. Please note there have
+been some changes to both the supported targets and which tier some targets are in, and there may be
+further changes to this made. Additionally, all relevant issues have been migrated to this
+repository.
 
-Join the discussion on Matrix! [#serialport-rs:matrix.org](https://matrix.to/#/#serialport-rs:matrix.org)
+Join the discussion on Matrix!
+[#serialport-rs:matrix.org](https://matrix.to/#/#serialport-rs:matrix.org)
 
-**This project is looking for maintainers! If you are interested please let us know on Matrix, or by [creating a Discussion](https://github.com/serialport/serialport-rs/discussions/new).**
+**This project is looking for maintainers! If you are interested please let us know on Matrix, or by
+[creating a discussion](https://github.com/serialport/serialport-rs/discussions/new).**
 
 # Introduction
 
@@ -19,7 +25,7 @@ For async I/O functionality, see the [mio-serial](https://github.com/berkowski/m
 # Overview
 
 The library exposes cross-platform serial port functionality through the `SerialPort` trait. This
-library is structured to make this the simplest API to use to encourate cross-platform development
+library is structured to make this the simplest API to use to encourage cross-platform development
 by default. Working with the resultant `Box<dyn SerialPort>` type is therefore recommended. To
 expose additional platform-specific functionality use the platform-specific structs directly:
 `TTYPort` for POSIX systems and `COMPort` for Windows.
@@ -34,7 +40,8 @@ can be removed by disabling the default `libudev` feature:
 $ cargo build --no-default-features
 ```
 
-It should also be noted that on macOS, both the Callout (`/dev/cu.*`) and Dial-in ports (`/dev/tty.*`) ports are enumerated, resulting in two available ports per connected serial device.
+It should also be noted that on macOS, both the Callout (`/dev/cu.*`) and Dial-in ports
+(`/dev/tty.*`) ports are enumerated, resulting in two available ports per connected serial device.
 
 # Usage
 
@@ -88,35 +95,40 @@ port is done when the `SerialPort` object is `Drop`ed either implicitly or expli
 There are several included examples, which help demonstrate the functionality of this library and
 can help debug software or hardware errors.
 
-- _clear_input_buffer_ - Demonstrates querying and clearing the driver input buffer
-- _clear_output_buffer_ - Demonstrates querying and clearing the driver output buffer
+- _clear_input_buffer_ - Demonstrates querying and clearing the driver input buffer.
+- _clear_output_buffer_ - Demonstrates querying and clearing the driver output buffer.
 - _duplex_ - Tests that a port can be successfully cloned.
 - _hardware_check_ - Checks port/driver functionality for a single port or a pair of ports connected
   to each other.
 - _list_ports_ - Lists available serial ports.
 - _pseudo_terminal_ - Unix only. Tests that a pseudo-terminal pair can be created.
 - _receive_data_ - Output data received on a port.
-- _transmit_ - Transmits data regularly on a port with various port configurations. Useful for debugging.
+- _transmit_ - Transmits data regularly on a port with various port configurations. Useful for
+  debugging.
 
 # Dependencies
 
 Rust versions 1.56.1 and higher are supported.
 
-For GNU Linux `pkg-config` headers are required:
+For GNU/Linux `pkg-config` headers are required:
 
 - Ubuntu: `sudo apt install pkg-config`
 - Fedora: `sudo dnf install pkgconf-pkg-config`
 
 For other distros they may provide `pkg-config` through the `pkgconf` package instead.
 
-For GNU Linux `libudev` headers are required as well (unless you disable the default `libudev` feature):
+For GNU/Linux `libudev` headers are required as well (unless you disable the default `libudev`
+feature):
 
 - Ubuntu: `sudo apt install libudev-dev`
 - Fedora: `sudo dnf install systemd-devel`
 
 # Platform Support
 
-Builds and tests for all supported targets are run in CI. Failures of either block the inclusion of new code. This library should be compatible with additional targets not listed below, but no guarantees are made. Additional platforms may be added in the future if there is a need and/or demand.
+Builds and tests for all supported targets are run in CI. Failures of either block the inclusion of
+new code. This library should be compatible with additional targets not listed below, but no
+guarantees are made. Additional platforms may be added in the future if there is a need and/or
+demand.
 
 - Android
   - `arm-linux-androideabi` (no serial enumeration)
@@ -130,7 +142,7 @@ Builds and tests for all supported targets are run in CI. Failures of either blo
   - `i686-unknown-linux-musl`
   - `x86_64-unknown-linux-gnu`
   - `x86_64-unknown-linux-musl`
-- MacOS/iOS
+- macOS/iOS
   - `aarch64-apple-darwin`
   - `aarch64-apple-ios`
   - `x86_64-apple-darwin`
@@ -144,14 +156,12 @@ Builds and tests for all supported targets are run in CI. Failures of either blo
 
 # Hardware Support
 
-This library has been developed to support all serial port devices across all
-supported platforms. To determine how well your platform is supported, please
-run the `hardware_check` example provided with this library. It will test the
-driver to confirm that all possible settings are supported for a port.
-Additionally, it will test that data transmission is correct for those settings
-if you have two ports physically configured to communicate. If you experience
-problems with your devices, please file a bug and identify the hardware, OS,
-and driver in use.
+This library has been developed to support all serial port devices across all supported platforms.
+To determine how well your platform is supported, please run the `hardware_check` example provided
+with this library. It will test the driver to confirm that all possible settings are supported for a
+port. Additionally, it will test that data transmission is correct for those settings if you have
+two ports physically configured to communicate. If you experience problems with your devices, please
+file a bug and identify the hardware, OS, and driver in use.
 
 Known issues:
 
@@ -165,7 +175,7 @@ Licensed under the [Mozilla Public License, version 2.0](https://www.mozilla.org
 
 # Contributing
 
-Please open an issue or merge request on GitLab to contibute. Code contributions submitted for
+Please open an issue or pull request on GitHub to contribute. Code contributions submitted for
 inclusion in the work by you, as defined in the MPL2.0 license, shall be licensed as the above
 without any additional terms or conditions.
 
@@ -174,4 +184,5 @@ without any additional terms or conditions.
 Special thanks to dcuddeback, willem66745, and apoloval who wrote the original serial-rs library
 which this library heavily borrows from.
 
-Additional thanks to susurrus and all other contributors to the original [serialport-rs](https://gitlab.com/susurrus/serialport-rs) project on GitLab.
+Additional thanks to susurrus and all other contributors to the original
+[serialport-rs](https://gitlab.com/susurrus/serialport-rs) project on GitLab.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![crates.io version badge](https://img.shields.io/crates/v/serialport.svg)](https://crates.io/crates/serialport)
 [![Documentation](https://docs.rs/serialport/badge.svg)](https://docs.rs/serialport)
 [![GitHub workflow status](https://img.shields.io/github/actions/workflow/status/serialport/serialport-rs/ci.yaml?branch=main&logo=github)](https://github.com/serialport/serialport-rs/actions)
+[![Minimum Stable Rust Version](https://img.shields.io/badge/Rust-1.56.1-blue?logo=rust)](https://blog.rust-lang.org/2021/11/01/Rust-1.56.1.html)
 
 > **Note:** This is a fork of the original
 [serialport-rs](https://gitlab.com/susurrus/serialport-rs) project on GitLab. Please note there have

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ can help debug software or hardware errors.
 
 # Dependencies
 
-Rust versions 1.46.0 and higher are supported.
+Rust versions 1.56.1 and higher are supported.
 
 For GNU Linux `pkg-config` headers are required:
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -9,7 +9,7 @@ With a single unconnected device:
 
 `cargo run --example hardware_check <DEVICE>`
 
-and when wired in a physical loopback mode
+And when wired in a physical loopback mode:
 
 `cargo run --example hardware_check <DEVICE> --loopback`
 
@@ -17,11 +17,11 @@ With two devices connected to each other:
 
  * `cargo run --example hardware_check <DEVICE1> --loopback-port <DEVICE2>`
  * Also `cargo run --example heartbeat <DEVICE1> <BAUD>` in one terminal and
-   `cargo run --example receive_data <DEVICE2> <BAUD>` in another.
+   `cargo run --example receive_data <DEVICE2> <BAUD>` in another
 
 Can also verify trickier settings (like non-standard baud rates) using serial terminal programs
 like:
 
   * `screen` (POSIX)
-  * [CoolTerm](http://freeware.the-meiers.org/) (OS X)
+  * [CoolTerm](http://freeware.the-meiers.org/) (macOS)
   * [RealTerm](https://sourceforge.net/projects/realterm/) (Windows)

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,206 @@
+# Note that all fields that take a lint level have these possible values:
+# * deny - An error will be produced and the check will fail
+# * warn - A warning will be produced, but the check will not fail
+# * allow - No warning or error will be produced, though in some cases a note
+# will be
+
+# If 1 or more target triples (and optionally, target_features) are specified,
+# only the specified targets will be checked when running `cargo deny check`.
+# This means, if a particular package is only ever used as a target specific
+# dependency, such as, for example, the `nix` crate only being used via the
+# `target_family = "unix"` configuration, that only having windows targets in
+# this list would mean the nix crate, as well as any of its exclusive
+# dependencies not shared by any other crates, would be ignored, as the target
+# list here is effectively saying which targets you are building for.
+targets = [
+    { triple = "aarch64-apple-darwin" },
+    { triple = "aarch64-apple-ios" },
+    { triple = "aarch64-unknown-linux-gnu" },
+    { triple = "aarch64-unknown-linux-musl" },
+    { triple = "arm-linux-androideabi" },
+    { triple = "armv7-linux-androideabi" },
+    { triple = "i686-pc-windows-gnu" },
+    { triple = "i686-pc-windows-msvc" },
+    { triple = "i686-unknwon-linux-gnu" },
+    { triple = "i686-unknown-linux-musl" },
+    { triple = "x86_64-apple-darwin" },
+    { triple = "x86_64-pc-windows-gnu" },
+    { triple = "x86_64-pc-windows-msvc" },
+    { triple = "x86_64-unknown-linux-gnu" },
+    { triple = "x86_64-unknown-linux-musl" },
+    { triple = "x86_64-unknown-netbsd" },
+]
+
+# This section is considered when running `cargo deny check advisories`
+# More documentation for the advisories section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
+[advisories]
+# The path where the advisory database is cloned/fetched into
+db-path = "~/.cargo/advisory-db"
+# The url(s) of the advisory databases to use
+db-urls = ["https://github.com/rustsec/advisory-db"]
+# The lint level for security vulnerabilities
+vulnerability = "deny"
+# The lint level for unmaintained crates
+unmaintained = "deny"
+# The lint level for crates that have been yanked from their source registry
+yanked = "deny"
+# The lint level for crates with security notices.
+notice = "deny"
+# A list of advisory IDs to ignore. Note that ignored advisories will still
+# output a note when they are encountered.
+ignore = [
+    "RUSTSEC-2020-0168", # caused by unmaintained mach dependency of core-foundation-sys
+    "RUSTSEC-2021-0145", # caused by unmaintained atty
+]
+# Threshold for security vulnerabilities, any vulnerability with a CVSS score
+# lower than the range specified will be ignored. Note that ignored advisories
+# will still output a note when they are encountered.
+# * None - CVSS Score 0.0
+# * Low - CVSS Score 0.1 - 3.9
+# * Medium - CVSS Score 4.0 - 6.9
+# * High - CVSS Score 7.0 - 8.9
+# * Critical - CVSS Score 9.0 - 10.0
+#severity-threshold =
+
+# If this is true, then cargo deny will use the git executable to fetch advisory database.
+# If this is false, then it uses a built-in git library.
+# Setting this to true can be helpful if you have special authentication requirements that cargo-deny does not support.
+# See Git Authentication for more information about setting up git authentication.
+#git-fetch-with-cli = true
+
+# This section is considered when running `cargo deny check licenses`
+# More documentation for the licenses section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
+[licenses]
+# The lint level for crates which do not have a detectable license
+unlicensed = "deny"
+# List of explicitly allowed licenses
+# See https://spdx.org/licenses/ for list of possible licenses
+# [possible values: any SPDX 3.11 short identifier (+ optional exception)].
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Unicode-DFS-2016",
+    "BSD-2-Clause",
+]
+# List of explicitly disallowed licenses
+# See https://spdx.org/licenses/ for list of possible licenses
+# [possible values: any SPDX 3.11 short identifier (+ optional exception)].
+deny = [
+    #"Nokia",
+]
+# Lint level for licenses considered copyleft
+copyleft = "allow"
+# Blanket approval or denial for OSI-approved or FSF Free/Libre licenses
+# * both - The license will be approved if it is both OSI-approved *AND* FSF
+# * either - The license will be approved if it is either OSI-approved *OR* FSF
+# * osi-only - The license will be approved if is OSI-approved *AND NOT* FSF
+# * fsf-only - The license will be approved if is FSF *AND NOT* OSI-approved
+# * neither - This predicate is ignored and the default lint level is used
+allow-osi-fsf-free = "neither"
+# Lint level used when no other predicates are matched
+# 1. License isn't in the allow or deny lists
+# 2. License isn't copyleft
+# 3. License isn't OSI/FSF, or allow-osi-fsf-free = "neither"
+default = "deny"
+# The confidence threshold for detecting a license from license text.
+# The higher the value, the more closely the license text must be to the
+# canonical license text of a valid SPDX license file.
+# [possible values: any between 0.0 and 1.0].
+confidence-threshold = 0.8
+# Allow 1 or more licenses on a per-crate basis, so that particular licenses
+# aren't accepted for every possible crate as with the normal allow list
+exceptions = [
+    # Each entry is the crate and version constraint, and its specific allow
+    # list
+    #{ allow = ["Zlib"], name = "adler32", version = "*" },
+]
+
+# Some crates don't have (easily) machine readable licensing information,
+# adding a clarification entry for it allows you to manually specify the
+# licensing information
+#[[licenses.clarify]]
+# The name of the crate the clarification applies to
+#name = "ring"
+# The optional version constraint for the crate
+#version = "*"
+# The SPDX expression for the license requirements of the crate
+#expression = "MIT AND ISC AND OpenSSL"
+# One or more files in the crate's source used as the "source of truth" for
+# the license expression. If the contents match, the clarification will be used
+# when running the license check, otherwise the clarification will be ignored
+# and the crate will be checked normally, which may produce warnings or errors
+# depending on the rest of your configuration
+#license-files = [
+    # Each entry is a crate relative path, and the (opaque) hash of its contents
+    #{ path = "LICENSE", hash = 0xbd0eed23 }
+#]
+
+[licenses.private]
+# If true, ignores workspace crates that aren't published, or are only
+# published to private registries.
+# To see how to mark a crate as unpublished (to the official registry),
+# visit https://doc.rust-lang.org/cargo/reference/manifest.html#the-publish-field.
+ignore = false
+# One or more private registries that you might publish crates to, if a crate
+# is only published to private registries, and ignore is true, the crate will
+# not have its license(s) checked
+registries = [
+    #"https://sekretz.com/registry
+]
+
+# This section is considered when running `cargo deny check bans`.
+# More documentation about the 'bans' section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html
+[bans]
+# Lint level for when multiple versions of the same crate are detected
+multiple-versions = "deny"
+# Lint level for when a crate version requirement is `*`
+wildcards = "deny"
+# The graph highlighting used when creating dotgraphs for crates
+# with multiple versions
+# * lowest-version - The path to the lowest versioned duplicate is highlighted
+# * simplest-path - The path to the version with the fewest edges is highlighted
+# * all - Both lowest-version and simplest-path are used
+highlight = "all"
+# List of crates that are allowed. Use with care!
+allow = [
+]
+# List of crates to deny
+deny = [
+]
+# Certain crates/versions that will be skipped when doing duplicate detection.
+skip = [
+]
+# Similarly to `skip` allows you to skip certain crates during duplicate
+# detection. Unlike skip, it also includes the entire tree of transitive
+# dependencies starting at the specified crate, up to a certain depth, which is
+# by default infinite
+skip-tree = [
+    { name = "clap", version = "~3.2" }, # https://github.com/serialport/serialport-rs/pull/76
+]
+
+# This section is considered when running `cargo deny check sources`.
+# More documentation about the 'sources' section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/sources/cfg.html
+[sources]
+# Lint level for what to happen when a crate from a crate registry that is not
+# in the allow list is encountered
+unknown-registry = "deny"
+# Lint level for what to happen when a crate from a git repository that is not
+# in the allow list is encountered
+unknown-git = "deny"
+# List of URLs for allowed crate registries. Defaults to the crates.io index
+# if not specified. If it is specified but empty, no registries are allowed.
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+# List of URLs for allowed Git repositories
+allow-git = []
+
+[sources.allow-org]
+# 1 or more github.com organizations to allow git sources for
+#github = [""]
+# 1 or more gitlab.com organizations to allow git sources for
+#gitlab = [""]
+# 1 or more bitbucket.org organizations to allow git sources for
+#bitbucket = [""]

--- a/doc/platforms.md
+++ b/doc/platforms.md
@@ -20,7 +20,7 @@ The BSDs basically **only** have the Termios2 API, but they call it Termios. It 
 
 ### FreeBSD
 
- * https://www.freebsd.org/doc/handbook/serial.html
+ * https://docs.freebsd.org/en/books/handbook/serialcomms/#serial
 
 ### NetBSD
 
@@ -33,8 +33,8 @@ The BSDs basically **only** have the Termios2 API, but they call it Termios. It 
 
  * https://man.openbsd.org/tty.4
 
-## Mac OS X and iOS
+## macOS and iOS
 
-While OS X and iOS have the heritage of a BSD, their support is slightly different. In theory, they support arbitrary baud rates in their Termios API much like the BSDs, but in practice this doesn't work with many hardware devices, as it's dependent on driver support. Instead, Apple added the `IOSSIOSPEED` ioctl in OS X 10.4, which can set the baud rate to an arbitrary value. As the oldest OS X version supported by Rust is 10.7, it's available on all Mac platforms.
+While macOS and iOS have the heritage of a BSD, their support is slightly different. In theory, they support arbitrary baud rates in their Termios API much like the BSDs, but in practice this doesn't work with many hardware devices, as it's dependent on driver support. Instead, Apple added the `IOSSIOSPEED` ioctl in Mac OS X 10.4, which can set the baud rate to an arbitrary value. As the oldest macOS version supported by Rust is 10.7, it's available on all Mac platforms.
 
 This API requires the port to be set into raw mode with `cfmakeraw`, and must be done after every call to `tcsetattr`, as that will reset the baud rate. Additionally, there is no way to retrieve the actual baud rate from the OS. This is therefore the clunkiest API of any platform.

--- a/doc/platforms.md
+++ b/doc/platforms.md
@@ -24,8 +24,8 @@ The BSDs basically **only** have the Termios2 API, but they call it Termios. It 
 
 ### NetBSD
 
- * http://netbsd.gw.com/cgi-bin/man-cgi?tty+4.i386+NetBSD-8.0
- * http://netbsd.gw.com/cgi-bin/man-cgi?com+4.i386+NetBSD-8.0
+ * https://man.netbsd.org/tty.4
+ * https://man.netbsd.org/com.4
  * https://www.netbsd.org/docs/Hardware/Misc/serial.html
  * https://www.netbsd.org/ports/hp300/faq.html
 

--- a/examples/loopback.rs
+++ b/examples/loopback.rs
@@ -1,0 +1,262 @@
+//! This example performs a loopback test using real hardware ports
+//!
+//! Additionally, some data will be collected and logged during the test to provide some
+//! rudimentary benchmarking information. When 'split-port' is specified, the serial port will
+//! be split into two channels that read/write "simultaneously" from multiple threads.
+//!
+//! You can also provide the length (in bytes) of data to test with, and the number of iterations to perform or
+//! a list of raw bytes to transmit.
+//!
+//! To run this example:
+//!
+//! 1) `cargo run --example loopback /dev/ttyUSB0`
+//!
+//! 2) `cargo run --example loopback /dev/ttyUSB0 --split-port`
+//!
+//! 3) `cargo run --example loopback /dev/ttyUSB0 -i 100 -l 32 -b 9600`
+//!
+//! 4) `cargo run --example loopback /dev/ttyUSB8 --bytes 222,173,190,239`
+
+use std::time::{Duration, Instant};
+
+use clap::Parser;
+use serialport::SerialPort;
+
+/// Serialport Example - Loopback
+#[derive(Parser)]
+struct Args {
+    /// The device path to a serialport
+    port: String,
+
+    /// The number of read/write iterations to perform
+    #[clap(short, long, default_value = "100")]
+    iterations: usize,
+
+    /// The number of bytes written per transaction
+    ///
+    /// Ignored when bytes are passed directly from the command-line
+    #[clap(short, long, default_value = "8")]
+    length: usize,
+
+    /// The baudrate to open the port with
+    #[clap(short, long, default_value = "115200")]
+    baudrate: u32,
+
+    /// Bytes to write to the serial port
+    ///
+    /// When not specified, the bytes transmitted count up
+    #[clap(long, use_value_delimiter = true)]
+    bytes: Option<Vec<u8>>,
+
+    /// Split the port to read/write from multiple threads
+    #[clap(long)]
+    split_port: bool,
+}
+
+fn main() {
+    let args = Args::parse();
+
+    // Open the serial port
+    let mut port = match serialport::new(&args.port, args.baudrate)
+        .timeout(Duration::MAX)
+        .open()
+    {
+        Err(e) => {
+            eprintln!("Failed to open \"{}\". Error: {}", args.port, e);
+            ::std::process::exit(1);
+        }
+        Ok(p) => p,
+    };
+
+    // Setup stat-tracking
+    let length = args.length;
+    let data: Vec<u8> = args
+        .bytes
+        .unwrap_or_else(|| (0..length).map(|i| i as u8).collect());
+
+    let (mut read_stats, mut write_stats) = Stats::new(args.iterations, &data);
+
+    // Run the tests
+    if args.split_port {
+        loopback_split(&mut port, &mut read_stats, &mut write_stats);
+    } else {
+        loopback_standard(&mut port, &mut read_stats, &mut write_stats);
+    }
+
+    // Print the results
+    println!("Loopback {}:", args.port);
+    println!("  data-length: {} bytes", read_stats.data.len());
+    println!("  iterations: {}", read_stats.iterations);
+    println!("  read:");
+    println!("    total: {:.6}s", read_stats.total());
+    println!("    average: {:.6}s", read_stats.average());
+    println!("    max: {:.6}s", read_stats.max());
+    println!("  write:");
+    println!("    total: {:.6}s", write_stats.total());
+    println!("    average: {:.6}s", write_stats.average());
+    println!("    max: {:.6}s", write_stats.max());
+    println!("  total: {:.6}s", read_stats.total() + write_stats.total());
+    println!(
+        "  bytes/s: {:.6}",
+        (read_stats.data.len() as f32) / (read_stats.average() + write_stats.average())
+    )
+}
+
+/// Capture read/write times to calculate average durations
+#[derive(Clone)]
+struct Stats<'a> {
+    pub data: &'a [u8],
+    pub times: Vec<Duration>,
+    pub iterations: usize,
+    now: Instant,
+}
+
+impl<'a> Stats<'a> {
+    /// Create new read/write stats
+    fn new(iterations: usize, data: &'a [u8]) -> (Self, Self) {
+        (
+            Self {
+                data,
+                times: Vec::with_capacity(iterations),
+                iterations,
+                now: Instant::now(),
+            },
+            Self {
+                data,
+                times: Vec::with_capacity(iterations),
+                iterations,
+                now: Instant::now(),
+            },
+        )
+    }
+
+    /// Start a duration timer
+    fn start(&mut self) {
+        self.now = Instant::now();
+    }
+
+    /// Store a duration
+    fn stop(&mut self) {
+        self.times.push(self.now.elapsed());
+    }
+
+    /// Provides the total time elapsed
+    fn total(&self) -> f32 {
+        self.times.iter().map(|d| d.as_secs_f32()).sum()
+    }
+
+    /// Provides average time per transaction
+    fn average(&self) -> f32 {
+        self.total() / (self.times.len() as f32)
+    }
+
+    /// Provides the maximum transation time
+    fn max(&self) -> f32 {
+        self.times
+            .iter()
+            .max()
+            .map(|d| d.as_secs_f32())
+            .unwrap_or(0.0)
+    }
+}
+
+fn loopback_standard<'a>(
+    port: &mut Box<dyn SerialPort>,
+    read_stats: &mut Stats<'a>,
+    write_stats: &mut Stats<'a>,
+) {
+    let mut buf = vec![0u8; read_stats.data.len()];
+
+    for _ in 0..read_stats.iterations {
+        // Write data to the port
+        write_stats.start();
+        port.write_all(write_stats.data)
+            .expect("failed to write to serialport");
+        write_stats.stop();
+
+        // Read data back from the port
+        read_stats.start();
+        port.read_exact(&mut buf)
+            .expect("failed to read from serialport");
+        read_stats.stop();
+
+        // Crash on error
+        for (i, x) in buf.iter().enumerate() {
+            if read_stats.data[i] != *x {
+                eprintln!(
+                    "Expected byte '{:02X}' but got '{:02X}'",
+                    read_stats.data[i], x
+                );
+                ::std::process::exit(2);
+            }
+        }
+    }
+}
+
+fn loopback_split<'a>(
+    port: &mut Box<dyn SerialPort>,
+    read_stats: &mut Stats<'a>,
+    write_stats: &mut Stats<'a>,
+) {
+    let mut buf = vec![0u8; read_stats.data.len()];
+    let mut rport = match port.try_clone() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("Failed to clone port: {}", e);
+            ::std::process::exit(3);
+        }
+    };
+
+    // Manage threads for read/writing; port usage is not async, so threads can easily deadlock:
+    //
+    // 1. Read Thread: Park -> Read -> Unpark Write ──────┐
+    //                 └──────────────────────────────────┘
+    // 2. Write Thread: Write -> Unpark Read -> Park ──────┐
+    //                  └──────────────────────────────────┘
+    std::thread::scope(|scope| {
+        // Get handle for writing thread
+        let wr_thread = std::thread::current();
+
+        // Spawn a thread that reads data for n iterations
+        let handle = scope.spawn(move || {
+            for _ in 0..read_stats.iterations {
+                // Wait for the write to complete
+                std::thread::park();
+
+                read_stats.start();
+                rport
+                    .read_exact(&mut buf)
+                    .expect("failed to read from serialport");
+                read_stats.stop();
+
+                // Crash on error
+                for (i, x) in buf.iter().enumerate() {
+                    if read_stats.data[i] != *x {
+                        eprintln!(
+                            "Expected byte '{:02X}' but got '{:02X}'",
+                            read_stats.data[i], x
+                        );
+                        ::std::process::exit(2);
+                    }
+                }
+
+                // Allow the writing thread to start
+                wr_thread.unpark();
+            }
+        });
+
+        // Write data to the port for n iterations
+        for _ in 0..write_stats.iterations {
+            write_stats.start();
+            port.write_all(write_stats.data)
+                .expect("failed to write to serialport");
+            write_stats.stop();
+
+            // Notify that the write completed
+            handle.thread().unpark();
+
+            // Wait for read to complete
+            std::thread::park();
+        }
+    });
+}

--- a/examples/transmit.rs
+++ b/examples/transmit.rs
@@ -26,7 +26,7 @@ fn main() {
                 .long("stop-bits")
                 .help("Number of stop bits to use")
                 .takes_value(true)
-                .possible_values(&["1", "2"])
+                .possible_values(["1", "2"])
                 .default_value("1"),
         )
         .arg(
@@ -34,7 +34,7 @@ fn main() {
                 .long("data-bits")
                 .help("Number of data bits to use")
                 .takes_value(true)
-                .possible_values(&["5", "6", "7", "8"])
+                .possible_values(["5", "6", "7", "8"])
                 .default_value("8"),
         )
         .arg(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,6 +143,17 @@ pub enum DataBits {
     Eight,
 }
 
+impl fmt::Display for DataBits {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            DataBits::Five => write!(f, "Five"),
+            DataBits::Six => write!(f, "Six"),
+            DataBits::Seven => write!(f, "Seven"),
+            DataBits::Eight => write!(f, "Eight"),
+        }
+    }
+}
+
 /// Parity checking modes
 ///
 /// When parity checking is enabled (`Odd` or `Even`) an extra bit is transmitted with
@@ -165,6 +176,16 @@ pub enum Parity {
     Even,
 }
 
+impl fmt::Display for Parity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            Parity::None => write!(f, "None"),
+            Parity::Odd => write!(f, "Odd"),
+            Parity::Even => write!(f, "Even"),
+        }
+    }
+}
+
 /// Number of stop bits
 ///
 /// Stop bits are transmitted after every character.
@@ -176,6 +197,15 @@ pub enum StopBits {
 
     /// Two stop bits.
     Two,
+}
+
+impl fmt::Display for StopBits {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            StopBits::One => write!(f, "One"),
+            StopBits::Two => write!(f, "Two"),
+        }
+    }
 }
 
 /// Flow control modes
@@ -190,6 +220,16 @@ pub enum FlowControl {
 
     /// Flow control using RTS/CTS signals.
     Hardware,
+}
+
+impl fmt::Display for FlowControl {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            FlowControl::None => write!(f, "None"),
+            FlowControl::Software => write!(f, "Software"),
+            FlowControl::Hardware => write!(f, "Hardware"),
+        }
+    }
 }
 
 /// Specifies which buffer or buffers to purge when calling [`clear`]
@@ -617,6 +657,38 @@ impl<T: SerialPort> SerialPort for &mut T {
 
     fn clear_break(&self) -> Result<()> {
         (**self).clear_break()
+    }
+}
+
+impl fmt::Debug for dyn SerialPort {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "SerialPort ( ")?;
+        match self.name().as_ref() {
+            Some(n) => write!(f, "name: {n} ")?,
+            None => {}
+        };
+        match self.baud_rate().as_ref() {
+            Ok(b) => write!(f, "baud_rate: {b}")?,
+            Err(_) => {}
+        };
+        match self.data_bits().as_ref() {
+            Ok(b) => write!(f, "data_bits: {b} ")?,
+            Err(_) => {}
+        };
+        match self.flow_control().as_ref() {
+            Ok(c) => write!(f, "flow_control: {c} ")?,
+            Err(_) => {}
+        }
+        match self.parity().as_ref() {
+            Ok(p) => write!(f, "parity: {p} ")?,
+            Err(_) => {}
+        }
+        match self.stop_bits().as_ref() {
+            Ok(s) => write!(f, "stop_bits: {s} ")?,
+            Err(_) => {}
+        }
+
+        write!(f, ")")
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -663,29 +663,23 @@ impl<T: SerialPort> SerialPort for &mut T {
 impl fmt::Debug for dyn SerialPort {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "SerialPort ( ")?;
-        match self.name().as_ref() {
-            Some(n) => write!(f, "name: {} ", n)?,
-            None => {}
+        if let Some(n) = self.name().as_ref() {
+            write!(f, "name: {} ", n)?;
         };
-        match self.baud_rate().as_ref() {
-            Ok(b) => write!(f, "baud_rate: {}", b)?,
-            Err(_) => {}
+        if let Ok(b) = self.baud_rate().as_ref() {
+            write!(f, "baud_rate: {}", b)?;
         };
-        match self.data_bits().as_ref() {
-            Ok(b) => write!(f, "data_bits: {} ", b)?,
-            Err(_) => {}
+        if let Ok(b) = self.data_bits().as_ref() {
+            write!(f, "data_bits: {} ", b)?;
         };
-        match self.flow_control().as_ref() {
-            Ok(c) => write!(f, "flow_control: {} ", c)?,
-            Err(_) => {}
+        if let Ok(c) = self.flow_control().as_ref() {
+            write!(f, "flow_control: {} ", c)?;
         }
-        match self.parity().as_ref() {
-            Ok(p) => write!(f, "parity: {} ", p)?,
-            Err(_) => {}
+        if let Ok(p) = self.parity().as_ref() {
+            write!(f, "parity: {} ", p)?;
         }
-        match self.stop_bits().as_ref() {
-            Ok(s) => write!(f, "stop_bits: {} ", s)?,
-            Err(_) => {}
+        if let Ok(s) = self.stop_bits().as_ref() {
+            write!(f, "stop_bits: {} ", s)?;
         }
 
         write!(f, ")")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -664,27 +664,27 @@ impl fmt::Debug for dyn SerialPort {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "SerialPort ( ")?;
         match self.name().as_ref() {
-            Some(n) => write!(f, "name: {n} ")?,
+            Some(n) => write!(f, "name: {} ", n)?,
             None => {}
         };
         match self.baud_rate().as_ref() {
-            Ok(b) => write!(f, "baud_rate: {b}")?,
+            Ok(b) => write!(f, "baud_rate: {}", b)?,
             Err(_) => {}
         };
         match self.data_bits().as_ref() {
-            Ok(b) => write!(f, "data_bits: {b} ")?,
+            Ok(b) => write!(f, "data_bits: {} ", b)?,
             Err(_) => {}
         };
         match self.flow_control().as_ref() {
-            Ok(c) => write!(f, "flow_control: {c} ")?,
+            Ok(c) => write!(f, "flow_control: {} ", c)?,
             Err(_) => {}
         }
         match self.parity().as_ref() {
-            Ok(p) => write!(f, "parity: {p} ")?,
+            Ok(p) => write!(f, "parity: {} ", p)?,
             Err(_) => {}
         }
         match self.stop_bits().as_ref() {
-            Ok(s) => write!(f, "stop_bits: {s} ")?,
+            Ok(s) => write!(f, "stop_bits: {} ", s)?,
             Err(_) => {}
         }
 

--- a/src/posix/enumerate.rs
+++ b/src/posix/enumerate.rs
@@ -125,10 +125,18 @@ fn get_int_property(
             prop_str.as_ptr(),
             kCFStringEncodingUTF8,
         );
+        let _key_guard = scopeguard::guard((), |_| {
+            CFRelease(key as *const c_void);
+        });
+
         let container = IORegistryEntryCreateCFProperty(device_type, key, kCFAllocatorDefault, 0);
         if container.is_null() {
             return None;
         }
+        let _container_guard = scopeguard::guard((), |_| {
+            CFRelease(container);
+        });
+
         let num = match cf_number_type {
             kCFNumberSInt16Type => {
                 let mut num: u16 = 0;
@@ -144,7 +152,6 @@ fn get_int_property(
             }
             _ => None,
         };
-        CFRelease(container);
 
         num
     }
@@ -160,10 +167,17 @@ fn get_string_property(device_type: io_registry_entry_t, property: &str) -> Opti
             prop_str.as_ptr(),
             kCFStringEncodingUTF8,
         );
+        let _key_guard = scopeguard::guard((), |_| {
+            CFRelease(key as *const c_void);
+        });
+
         let container = IORegistryEntryCreateCFProperty(device_type, key, kCFAllocatorDefault, 0);
         if container.is_null() {
             return None;
         }
+        let _container_guard = scopeguard::guard((), |_| {
+            CFRelease(container);
+        });
 
         let mut buf = Vec::with_capacity(256);
         let result = CFStringGetCString(
@@ -177,8 +191,6 @@ fn get_string_property(device_type: io_registry_entry_t, property: &str) -> Opti
         } else {
             None
         };
-
-        CFRelease(container);
 
         opt_str
     }
@@ -229,6 +241,9 @@ cfg_if! {
                         "IOServiceMatching returned a NULL dictionary.",
                     ));
                 }
+                let _classes_to_match_guard = scopeguard::guard((), |_| {
+                    CFRelease(classes_to_match as *const c_void);
+                });
 
                 // Populate the search dictionary with a single key/value pair indicating that we're
                 // searching for serial devices matching the RS232 device type.
@@ -243,6 +258,10 @@ cfg_if! {
                         "Failed to allocate key string.",
                     ));
                 }
+                let _key_guard = scopeguard::guard((), |_| {
+                    CFRelease(key as *const c_void);
+                });
+
                 let value = CFStringCreateWithCString(
                     kCFAllocatorDefault,
                     kIOSerialBSDAllTypes(),
@@ -254,6 +273,10 @@ cfg_if! {
                         "Failed to allocate value string.",
                     ));
                 }
+                let _value_guard = scopeguard::guard((), |_| {
+                    CFRelease(value as *const c_void);
+                });
+
                 CFDictionarySetValue(classes_to_match, key as CFTypeRef, value as CFTypeRef);
 
                 // Get an interface to IOKit
@@ -270,7 +293,7 @@ cfg_if! {
                 let mut matching_services = MaybeUninit::uninit();
                 kern_result = IOServiceGetMatchingServices(
                     kIOMasterPortDefault,
-                    classes_to_match,
+                    CFRetain(classes_to_match as *const c_void) as *const __CFDictionary,
                     matching_services.as_mut_ptr(),
                 );
                 if kern_result != KERN_SUCCESS {
@@ -280,15 +303,20 @@ cfg_if! {
                     ));
                 }
                 let matching_services = matching_services.assume_init();
+                let _matching_services_guard = scopeguard::guard((), |_| {
+                    IOObjectRelease(matching_services);
+                });
 
                 loop {
                     // Grab the next result.
                     let modem_service = IOIteratorNext(matching_services);
-
                     // Break out if we've reached the end of the iterator
                     if modem_service == MACH_PORT_NULL {
                         break;
                     }
+                    let _modem_service_guard = scopeguard::guard((), |_| {
+                        IOObjectRelease(modem_service);
+                    });
 
                     // Fetch all properties of the current search result item.
                     let mut props = MaybeUninit::uninit();
@@ -298,6 +326,10 @@ cfg_if! {
                         kCFAllocatorDefault,
                         0,
                     );
+                    let _props_guard = scopeguard::guard((), |_| {
+                        CFRelease(props.assume_init() as *const c_void);
+                    });
+
                     if result == KERN_SUCCESS {
                         for key in ["IOCalloutDevice", "IODialinDevice"].iter() {
                             let key = CString::new(*key).unwrap();
@@ -306,6 +338,10 @@ cfg_if! {
                                 key.as_ptr(),
                                 kCFStringEncodingUTF8,
                             );
+                            let _key_cfstring_guard = scopeguard::guard((), |_| {
+                                CFRelease(key_cfstring as *const c_void);
+                            });
+
                             let value = CFDictionaryGetValue(props.assume_init(), key_cfstring as *const c_void);
 
                             let type_id = CFGetTypeID(value);
@@ -333,9 +369,6 @@ cfg_if! {
                     } else {
                         return Err(Error::new(ErrorKind::Unknown, format!("ERROR: {}", result)));
                     }
-
-                    // Clean up after we're done processing htis result
-                    IOObjectRelease(modem_service);
                 }
             }
             Ok(vec)

--- a/src/posix/enumerate.rs
+++ b/src/posix/enumerate.rs
@@ -137,7 +137,7 @@ fn get_int_property(
             CFRelease(container);
         });
 
-        let num = match cf_number_type {
+        match cf_number_type {
             kCFNumberSInt16Type => {
                 let mut num: u16 = 0;
                 let num_ptr: *mut c_void = &mut num as *mut _ as *mut c_void;
@@ -151,9 +151,7 @@ fn get_int_property(
                 Some(num)
             }
             _ => None,
-        };
-
-        num
+        }
     }
 }
 

--- a/src/posix/enumerate.rs
+++ b/src/posix/enumerate.rs
@@ -31,7 +31,8 @@ use crate::UsbPortInfo;
     target_os = "ios",
     all(target_os = "linux", not(target_env = "musl"), feature = "libudev"),
     target_os = "macos",
-    target_os = "netbsd"
+    target_os = "netbsd",
+    target_os = "openbsd",
 ))]
 use crate::{Error, ErrorKind};
 use crate::{Result, SerialPortInfo};

--- a/src/posix/enumerate.rs
+++ b/src/posix/enumerate.rs
@@ -164,12 +164,18 @@ fn get_string_property(device_type: io_registry_entry_t, property: &str) -> Opti
             return None;
         }
 
-        let str_ptr = CFStringGetCStringPtr(container as CFStringRef, kCFStringEncodingMacRoman);
-        if str_ptr.is_null() {
-            CFRelease(container);
-            return None;
-        }
-        let opt_str = CStr::from_ptr(str_ptr).to_str().ok().map(String::from);
+        let mut buf = Vec::with_capacity(256);
+        let result = CFStringGetCString(
+            container as CFStringRef,
+            buf.as_mut_ptr(),
+            buf.capacity() as i64,
+            kCFStringEncodingUTF8,
+        );
+        let opt_str = if result != 0 {
+            CStr::from_ptr(buf.as_ptr()).to_str().ok().map(String::from)
+        } else {
+            None
+        };
 
         CFRelease(container);
 

--- a/src/posix/ioctl.rs
+++ b/src/posix/ioctl.rs
@@ -118,8 +118,9 @@ pub fn tiocnxcl(fd: RawFd) -> Result<()> {
 
 pub fn tiocmget(fd: RawFd) -> Result<SerialLines> {
     let mut status: libc::c_int = 0;
-    let x = unsafe { raw::tiocmget(fd, &mut status) };
-    x.map(SerialLines::from_bits_truncate).map_err(|e| e.into())
+    unsafe { raw::tiocmget(fd, &mut status) }
+        .map(|_| SerialLines::from_bits_truncate(status))
+        .map_err(|e| e.into())
 }
 
 pub fn tiocsbrk(fd: RawFd) -> Result<()> {

--- a/src/posix/poll.rs
+++ b/src/posix/poll.rs
@@ -29,7 +29,11 @@ fn wait_fd(fd: RawFd, events: PollFlags, timeout: Duration) -> io::Result<()> {
     #[cfg(target_os = "linux")]
     let wait_res = {
         let timespec = TimeSpec::milliseconds(milliseconds);
-        nix::poll::ppoll(slice::from_mut(&mut fd), Some(timespec), SigSet::empty())
+        nix::poll::ppoll(
+            slice::from_mut(&mut fd),
+            Some(timespec),
+            Some(SigSet::empty()),
+        )
     };
     #[cfg(not(target_os = "linux"))]
     let wait_res = nix::poll::poll(slice::from_mut(&mut fd), milliseconds as nix::libc::c_int);

--- a/src/posix/tty.rs
+++ b/src/posix/tty.rs
@@ -79,7 +79,7 @@ struct OwnedFd(RawFd);
 
 impl Drop for OwnedFd {
     fn drop(&mut self) {
-        let _ = close(self.0);
+        close(self.0);
     }
 }
 
@@ -208,12 +208,9 @@ impl TTYPort {
             ioctl::tiocnxcl(self.fd)
         };
 
-        if let Err(err) = setting_result {
-            Err(err)
-        } else {
-            self.exclusive = exclusive;
-            Ok(())
-        }
+        setting_result?;
+        self.exclusive = exclusive;
+        Ok(())
     }
 
     fn set_pin(&mut self, pin: ioctl::SerialLines, level: bool) -> Result<()> {

--- a/src/posix/tty.rs
+++ b/src/posix/tty.rs
@@ -37,6 +37,21 @@ fn close(fd: RawFd) {
 /// should not be instantiated directly by using `TTYPort::open()`, instead use
 /// the cross-platform `serialport::open()` or
 /// `serialport::open_with_settings()`.
+///
+/// Note: on macOS, when connecting to a pseudo-terminal (`pty` opened via
+/// `posix_openpt`), the `baud_rate` should be set to 0; this will be used to
+/// explicitly _skip_ an attempt to set the baud rate of the file descriptor
+/// that would otherwise happen via an `ioctl` command.
+///
+/// ```
+/// use serialport::{TTYPort, SerialPort};
+///
+/// let (mut master, slave) = TTYPort::pair().expect("Unable to create ptty pair");
+///
+/// // ... elsewhere
+///
+/// let mut port = TTYPort::open(&serialport::new(slave.name().unwrap(), 0)).expect("unable to open");
+/// ```
 #[derive(Debug)]
 pub struct TTYPort {
     fd: RawFd,

--- a/src/posix/tty.rs
+++ b/src/posix/tty.rs
@@ -458,7 +458,7 @@ impl SerialPort for TTYPort {
 
         assert!(termios2.c_ospeed == termios2.c_ispeed);
 
-        Ok(termios2.c_ospeed as u32)
+        Ok(termios2.c_ospeed)
     }
 
     /// Returns the port's baud rate

--- a/src/windows/enumerate.rs
+++ b/src/windows/enumerate.rs
@@ -4,7 +4,6 @@ use std::{mem, ptr};
 use regex::Regex;
 use winapi::shared::guiddef::*;
 use winapi::shared::minwindef::*;
-use winapi::shared::ntdef::CHAR;
 use winapi::shared::winerror::*;
 use winapi::um::cguid::GUID_NULL;
 use winapi::um::errhandlingapi::GetLastError;
@@ -244,30 +243,34 @@ impl PortDevice {
     // Retrieves a device property and returns it, if it exists. Returns None if the property
     // doesn't exist.
     fn property(&mut self, property_id: DWORD) -> Option<String> {
-        let mut result_buf: [CHAR; MAX_PATH] = [0; MAX_PATH];
+        let mut property_buf = [0u16; MAX_PATH];
+
         let res = unsafe {
-            SetupDiGetDeviceRegistryPropertyA(
+            SetupDiGetDeviceRegistryPropertyW(
                 self.hdi,
                 &mut self.devinfo_data,
                 property_id,
                 ptr::null_mut(),
-                result_buf.as_mut_ptr() as PBYTE,
-                (result_buf.len() - 1) as DWORD,
+                property_buf.as_mut_ptr() as PBYTE,
+                property_buf.len() as DWORD,
                 ptr::null_mut(),
             )
         };
+
         if res == FALSE {
             if unsafe { GetLastError() } != ERROR_INSUFFICIENT_BUFFER {
                 return None;
             }
         }
-        let end_of_buffer = result_buf.len() - 1;
-        result_buf[end_of_buffer] = 0;
-        Some(unsafe {
-            CStr::from_ptr(result_buf.as_ptr())
-                .to_string_lossy()
-                .into_owned()
-        })
+
+        // Using the unicode version of 'SetupDiGetDeviceRegistryProperty' seems to report the
+        // entire mfg registry string. This typically includes some driver information that we should discard.
+        // Example string: 'FTDI5.inf,%ftdi%;FTDI'
+        String::from_utf16_lossy(&property_buf)
+            .trim_end_matches(0 as char)
+            .split(';')
+            .last()
+            .map(str::to_string)
     }
 }
 


### PR DESCRIPTION
We have integrated several fixes since releasing [4.2.0](https://github.com/serialport/serialport-rs/releases/tag/v4.2.0) but the current main branch breaks semantic versioning due to the field `interface` added to `UsbPortInfo` with 364e1fb957279194a29e74acc435788557182dc2.

There is demand for a maintenance release from our [Matrix channel](https://matrix.to/#/!cnJwoUGZmLziNcGNua:matrix.org/$PbYEq2VsssJlcDt4qdR0UnZAEgMCVBGUH3T7sdg6zFo?via=matrix.org&via=t2bot.io&via=sinic.eu) to release the changes from #98. What about cutting it as everything from _main_ but the breaking changes?

I've checked semantic version compatibility as follows:
```
$ cargo semver-checks check-release --baseline-version 4.2.0
    Updating index
     Parsing serialport v4.2.1-alpha.0 (current)
     Parsing serialport v4.2.0 (baseline, cached)
    Checking serialport v4.2.0 -> v4.2.1-alpha.0 (patch change)
   Completed [   0.013s] 43 checks; 43 passed, 0 unnecessary
```

This PR is for discussing the actual changes and populating the release branch with them. Once we agree that this moves into the right direction, I will do the housekeeping and update version, changelog, ...