### PR TITLE
Add feature gate for UsbPortInfo.interface (for releasing 4.2.1 from main)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -78,20 +78,38 @@ jobs:
       - name: Build | rust-cache
         uses: Swatinem/rust-cache@v1
 
-      - name: Build | build library
+      - name: Build | build library (default features)
         uses: actions-rs/cargo@v1
         with:
           command: build
           args: --target=${{ inputs.target }}
 
-      - name: Build | build examples
+      - name: Build | build library (all features)
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --all-features --target=${{ inputs.target }}
+
+      - name: Build | build examples (default features)
         if: ${{ inputs.disable_extra_builds == false }}
         run: cargo build --examples --target=${{ inputs.target }}
 
-      - name: Build | build tests
+      - name: Build | build examples (all features)
+        if: ${{ inputs.disable_extra_builds == false }}
+        run: cargo build --examples --all-features --target=${{ inputs.target }}
+
+      - name: Build | build tests (default features)
         if: ${{ inputs.disable_extra_builds == false }}
         run: cargo build --tests --target=${{ inputs.target }}
 
-      - name: Build | run tests
+      - name: Build | run tests (default features)
         if: ${{ inputs.disable_tests == false }}
         run: cargo test --no-fail-fast --target=${{ inputs.target }}
+
+      - name: Build | build tests (all features)
+        if: ${{ inputs.disable_extra_builds == false }}
+        run: cargo build --tests --all-features --target=${{ inputs.target }}
+
+      - name: Build | run tests (all features)
+        if: ${{ inputs.disable_tests == false }}
+        run: cargo test --no-fail-fast --all-features --target=${{ inputs.target }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,33 @@ project adheres to [Semantic Versioning](https://semver.org/).
 
 ## UNRELEASED
 ### Added
+* Add support for reporting the USB device interface (feature-gated by
+  _usbserialinfo-interface_).
+  [#47](https://github.com/serialport/serialport-rs/pull/47),
+  [#101](https://github.com/serialport/serialport-rs/pull/101)
+* Add example for loopback testing with real hardware.
+  [#69](https://github.com/serialport/serialport-rs/pull/69)
+* Implement `fmt::Debug` and `fmt::Display` for `SerialPort` and related enums.
+  [#91](https://github.com/serialport/serialport-rs/pull/91)
 ### Changed
+* Migrated from unmaintainted dependency `mach` to `mach2`.
+* Update dependency `nix` from 0.24.1 to 0.26.0 and raise MSRV to 1.56.1.
+  [#67](https://github.com/serialport/serialport-rs/pull/67),
+  [#75](https://github.com/serialport/serialport-rs/pull/75),
+  [#78](https://github.com/serialport/serialport-rs/pull/78)
 ### Fixed
-* A number of memory leaks have been addressed when using serialport-rs on
-macOS. In particular, enumerating USB ports and not discovering any could
-quickly consume 1GiB of memory in a minute or so. More generally, if you are using serialport-rs
-on macOS then please upgrade to this version as soon as possible.
+* Skip attempts to set baud rate 0 on macOS.
+  [#58](https://github.com/serialport/serialport-rs/pull/58)
+* Fix getting actual result value from `tiocmget`.
+  [#61](https://github.com/serialport/serialport-rs/pull/61/files)
+* Fix serial number retrieval procedure on macOS.
+  [#65](https://github.com/serialport/serialport-rs/pull/65)
+* Fix port name retrieval procedure for Unicode names on Windows.
+  [#63](https://github.com/serialport/serialport-rs/pull/63)
+* Fix compilation for OpenBSD due to missing use declaration.
+  [#68](https://github.com/serialport/serialport-rs/pull/68)
+* A number of memory leaks have been addressed when using serialport-rs.
+  [#98](https://github.com/serialport/serialport-rs/pull/98)
 ### Removed
 
 ## [4.2.0] - 2022-06-02

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,3 +46,6 @@ clap = { version = "3.1.6", features = ["derive"] }
 
 [features]
 default = ["libudev"]
+# TODO: Make the feature unconditionally available with the next major release
+# (5.0) and remove this feature gate.
+usbportinfo-interface = []

--- a/examples/list_ports.rs
+++ b/examples/list_ports.rs
@@ -26,6 +26,7 @@ fn main() {
                             "           Product: {}",
                             info.product.as_ref().map_or("", String::as_str)
                         );
+                        #[cfg(feature = "usbportinfo-interface")]
                         println!(
                             "         Interface: {}",
                             info.interface

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,12 @@
     missing_copy_implementations,
     unused
 )]
+// Document feature-gated elements on docs.rs. See
+// https://doc.rust-lang.org/rustdoc/unstable-features.html?highlight=doc(cfg#doccfg-recording-what-platforms-or-features-are-required-for-code-to-be-present
+// and
+// https://doc.rust-lang.org/rustdoc/unstable-features.html#doc_auto_cfg-automatically-generate-doccfg
+// for details.
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Don't worry about needing to `unwrap()` or otherwise handle some results in
 // doc tests.
 #![doc(test(attr(allow(unused_must_use))))]
@@ -702,6 +708,7 @@ pub struct UsbPortInfo {
     /// Product name (arbitrary string)
     pub product: Option<String>,
     /// Interface (id number for multiplexed devices)
+    #[cfg(feature = "usbportinfo-interface")]
     pub interface: Option<u8>,
 }
 

--- a/src/posix/enumerate.rs
+++ b/src/posix/enumerate.rs
@@ -82,6 +82,7 @@ fn port_type(d: &libudev::Device) -> Result<SerialPortType> {
                     .or_else(|| udev_property_as_string(d, "ID_VENDOR")),
                 product: udev_property_as_string(d, "ID_MODEL_FROM_DATABASE")
                     .or_else(|| udev_property_as_string(d, "ID_MODEL")),
+                #[cfg(feature = "usbportinfo-interface")]
                 interface: udev_hex_property_as_int(d, "ID_USB_INTERFACE_NUM", &u8::from_str_radix)
                     .ok(),
             }))
@@ -233,6 +234,7 @@ fn port_type(service: io_object_t) -> SerialPortType {
             //
             // https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_driverkit_transport_usb
             // https://developer.apple.com/library/archive/documentation/DeviceDrivers/Conceptual/USBBook/USBOverview/USBOverview.html#//apple_ref/doc/uid/TP40002644-BBCEACAJ
+            #[cfg(feature = "usbportinfo-interface")]
             interface: get_int_property(usb_device, "bInterfaceNumber", kCFNumberSInt8Type)
                 .map(|x| x as u8),
         })

--- a/src/windows/enumerate.rs
+++ b/src/windows/enumerate.rs
@@ -106,6 +106,7 @@ fn parse_usb_port_info(hardware_id: &str) -> Option<UsbPortInfo> {
         serial_number: caps.name("serial").map(|m| m.as_str().to_string()),
         manufacturer: None,
         product: None,
+        #[cfg(feature = "usbportinfo-interface")]
         interface: caps
             .name("iid")
             .and_then(|m| u8::from_str_radix(m.as_str(), 16).ok()),
@@ -326,6 +327,7 @@ fn test_parsing_usb_port_information() {
     assert_eq!(info.pid, 0x6018);
     // FIXME: The 'serial number' as reported by the HWID likely needs some review
     assert_eq!(info.serial_number, Some("6".to_string()));
+    #[cfg(feature = "usbportinfo-interface")]
     assert_eq!(info.interface, Some(2));
 
     let ftdi_serial_hwid = r"FTDIBUS\VID_0403+PID_6001+A702TB52A\0000";
@@ -334,6 +336,7 @@ fn test_parsing_usb_port_information() {
     assert_eq!(info.vid, 0x0403);
     assert_eq!(info.pid, 0x6001);
     assert_eq!(info.serial_number, Some("A702TB52A".to_string()));
+    #[cfg(feature = "usbportinfo-interface")]
     assert_eq!(info.interface, None);
 
     let pyboard_hwid = r"USB\VID_F055&PID_9802\385435603432";
@@ -342,5 +345,6 @@ fn test_parsing_usb_port_information() {
     assert_eq!(info.vid, 0xF055);
     assert_eq!(info.pid, 0x9802);
     assert_eq!(info.serial_number, Some("385435603432".to_string()));
+    #[cfg(feature = "usbportinfo-interface")]
     assert_eq!(info.interface, None);
 }


### PR DESCRIPTION
Adding this field unconditionally is a major breaking change with respect to semantic versioning. Putting it behind a feature gate allows to ship this information early and also still cut 4.x releases from the main branch while still working towards 5.0.

This is an alternative draft to creating (and maintaining) a separate 4.2 release branch as proposed with #100. All maintainers look busy as of now and this approach looks like it allows us to keep a low profile.

I prefer this approach over #100 and if we agree on this way I will prepare the release.



