### PR TITLE
Release 4.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -348,7 +348,7 @@ Unreleased, happened due to a user error using `cargo-release`.
 
 
 [Unreleased]: https://github.com/serialport/serialport-rs/compare/v4.2.1...HEAD
-[4.2.1]: https://github.com/serialport/serialport-rs/compare/v4.2.1...v4.2.1
+[4.2.1]: https://github.com/serialport/serialport-rs/compare/v4.2.0...v4.2.1
 [4.2.0]: https://github.com/serialport/serialport-rs/compare/v4.1.0...v4.2.0
 [4.1.0]: https://github.com/serialport/serialport-rs/compare/v4.0.1...v4.1.0
 [4.0.1]: https://github.com/serialport/serialport-rs/compare/v4.0.0...v4.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/) and this
 project adheres to [Semantic Versioning](https://semver.org/).
 
-## UNRELEASED
+## [Unreleased]
+### Added
+### Changed
+### Fixed
+### Removed
+
+## [4.2.1] - 2023-05-21
 ### Added
 * Add support for reporting the USB device interface (feature-gated by
   _usbserialinfo-interface_).
@@ -341,6 +347,8 @@ Unreleased, happened due to a user error using `cargo-release`.
 * Initial release.
 
 
+[Unreleased]: https://github.com/serialport/serialport-rs/compare/v4.2.1...HEAD
+[4.2.1]: https://github.com/serialport/serialport-rs/compare/v4.2.1...v4.2.1
 [4.2.0]: https://github.com/serialport/serialport-rs/compare/v4.1.0...v4.2.0
 [4.1.0]: https://github.com/serialport/serialport-rs/compare/v4.0.1...v4.1.0
 [4.0.1]: https://github.com/serialport/serialport-rs/compare/v4.0.0...v4.0.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serialport"
-version = "4.2.1-alpha.0"
+version = "4.2.1"
 authors = [
     "Bryant Mairs <bryant@mai.rs>",
     "Jesse Braham <jesse@beta7.io>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serialport"
-version = "4.2.1"
+version = "4.2.2-alpha.0"
 authors = [
     "Bryant Mairs <bryant@mai.rs>",
     "Jesse Braham <jesse@beta7.io>",


### PR DESCRIPTION
* A follow-up to #101 finally preparing release 4.2.1
* Will tag the merged release commit and create the GitHub release item when this PR has landed
* And then it is time to publish the merged release commit to crates.io