### PR TITLE
use libudev on musl linux with libudev feature

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -62,7 +62,7 @@ jobs:
           sudo apt-get -qq -y install build-essential curl git pkg-config ${{ inputs.extra_packages }}
 
       - name: Build | install void dependencies
-        if: contains(inputs.container, 'void-linux')
+        if: contains(inputs.image, 'void-linux')
         run: |
           xbps-install -Syu || xbps-install -yu xbps
           xbps-install -yu base-devel bash curl git ${{ inputs.extra_packages }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -91,6 +91,7 @@ jobs:
             --no-scripts \
             alpine-base ${{ inputs.extra_sysroot_packages }}
           echo "PKG_CONFIG_SYSROOT_DIR=$PWD/sysroot" >> $GITHUB_ENV
+          echo "PKG_CONFIG_PATH=$PWD/sysroot/usr/lib/pkgconfig" >> $GITHUB_ENV
 
       - name: Build | add mingw32 to path
         if: inputs.runs_on == 'windows-2019'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,6 +9,8 @@ on:
         type: boolean
       extra_packages:
         type: string
+      image:
+        type: string
       runs_on:
         default: ubuntu-latest
         type: string
@@ -24,20 +26,20 @@ env:
   # defining all environment variables for each job. This has the added benefit
   # of keeping them all together in one place.
   CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
-  CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER: aarch64-linux-gnu-gcc
+  CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER: aarch64-linux-musl-gcc
   CARGO_TARGET_ARMV5TE_UNKNOWN_LINUX_GNUEABI_LINKER: arm-linux-gnueabi-gcc
-  CARGO_TARGET_ARMV5TE_UNKNOWN_LINUX_MUSLEABI_LINKER: arm-linux-gnueabi-gcc
+  CARGO_TARGET_ARMV5TE_UNKNOWN_LINUX_MUSLEABI_LINKER: arm-linux-musleabi-gcc
   CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER: arm-linux-gnueabihf-gcc
-  CARGO_TARGET_ARMV7_UNKNOWN_LINUX_MUSLEABIHF_LINKER: arm-linux-gnueabihf-gcc
+  CARGO_TARGET_ARMV7_UNKNOWN_LINUX_MUSLEABIHF_LINKER: arm-linux-musleabihf-gcc
   CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_LINKER: arm-linux-gnueabihf-gcc
   CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABI_LINKER: arm-linux-gnueabi-gcc
-  CARGO_TARGET_ARM_UNKNOWN_LINUX_MUSLEABI_LINKER: arm-linux-gnueabi-gcc
+  CARGO_TARGET_ARM_UNKNOWN_LINUX_MUSLEABI_LINKER: arm-linux-musleabi-gcc
   CARGO_TARGET_MIPS64EL_UNKNOWN_LINUX_GNUABI64_LINKER: mips64el-linux-gnuabi64-gcc
   CARGO_TARGET_MIPS64_UNKNOWN_LINUX_GNUABI64_LINKER: mips64-linux-gnuabi64-gcc
   CARGO_TARGET_MIPSEL_UNKNOWN_LINUX_GNU_LINKER: mipsel-linux-gnu-gcc
-  CARGO_TARGET_MIPSEL_UNKNOWN_LINUX_MUSL_LINKER: mipsel-linux-gnu-gcc
+  CARGO_TARGET_MIPSEL_UNKNOWN_LINUX_MUSL_LINKER: mipsel-linux-musl-gcc
   CARGO_TARGET_MIPS_UNKNOWN_LINUX_GNU_LINKER: mips-linux-gnu-gcc
-  CARGO_TARGET_MIPS_UNKNOWN_LINUX_MUSL_LINKER: mips-linux-gnu-gcc
+  CARGO_TARGET_MIPS_UNKNOWN_LINUX_MUSL_LINKER: mips-linux-musl-gcc
   CARGO_TARGET_POWERPC64LE_UNKNOWN_LINUX_GNU_LINKER: powerpc64le-linux-gnu-gcc
   CARGO_TARGET_POWERPC64_UNKNOWN_LINUX_GNU_LINKER: powerpc64-linux-gnu-gcc
   CARGO_TARGET_POWERPC_UNKNOWN_LINUX_GNU_LINKER: powerpc-linux-gnu-gcc
@@ -50,13 +52,20 @@ env:
 jobs:
   build:
     runs-on: ${{ inputs.runs_on }}
+    container: ${{ inputs.image }}
     steps:
-      - name: Build | install dependencies
-        if: inputs.runs_on == 'ubuntu-latest'
+      - name: Build | install ubuntu dependencies
+        if: inputs.runs_on == 'ubuntu-latest' && !inputs.image
         run: |
           sudo sed -i 's/azure.archive.ubuntu.com/archive.ubuntu.com/' /etc/apt/sources.list
           sudo apt-get -qq update
           sudo apt-get -qq -y install build-essential curl git pkg-config ${{ inputs.extra_packages }}
+
+      - name: Build | install void dependencies
+        if: contains(inputs.container, 'void-linux')
+        run: |
+          xbps-install -Syu || xbps-install -yu xbps
+          xbps-install -yu base-devel curl git ${{ inputs.extra_packages }}
 
       - name: Build | add mingw32 to path
         if: inputs.runs_on == 'windows-2019'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,6 +9,8 @@ on:
         type: boolean
       extra_packages:
         type: string
+      extra_sysroot_packages:
+        type: string
       image:
         type: string
       runs_on:
@@ -65,7 +67,30 @@ jobs:
         if: contains(inputs.image, 'void-linux')
         run: |
           xbps-install -Syu || xbps-install -yu xbps
-          xbps-install -yu base-devel bash curl git ${{ inputs.extra_packages }}
+          xbps-install -yu apk-tools base-devel bash curl git ${{ inputs.extra_packages }}
+
+      - name: Build | install alpine dependencies
+        id: sysroot-deps
+        if: contains(inputs.image, 'void-linux')
+        run: |
+          mkdir sysroot
+          case "${{inputs.target}}" in
+            aarch64-*) _arch=aarch64 ;;
+            i686-*) _arch=x86 ;;
+            x86_64-*) _arch=x86_64 ;;
+          esac
+          cat << REPOSITORIES > repositories
+          https://dl-cdn.alpinelinux.org/alpine/v3.18/main/
+          REPOSITORIES
+          apk add \
+            --root sysroot \
+            --arch $_arch \
+            --initdb \
+            --repositories-file repositories \
+            --allow-untrusted \
+            --no-scripts \
+            alpine-base ${{ inputs.extra_sysroot_packages }}
+          echo "args=--sysroot $PWD/sysroot" >> $GITHUB_OUTPUT
 
       - name: Build | add mingw32 to path
         if: inputs.runs_on == 'windows-2019'
@@ -91,34 +116,34 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --target=${{ inputs.target }}
+          args: --target=${{ inputs.target }} ${{ steps.sysroot-deps.outputs.args }}
 
       - name: Build | build library (all features)
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --all-features --target=${{ inputs.target }}
+          args: --all-features --target=${{ inputs.target }} ${{ steps.sysroot-deps.outputs.args }}
 
       - name: Build | build examples (default features)
         if: ${{ inputs.disable_extra_builds == false }}
-        run: cargo build --examples --target=${{ inputs.target }}
+        run: cargo build --examples --target=${{ inputs.target }} ${{ steps.sysroot-deps.outputs.args }}
 
       - name: Build | build examples (all features)
         if: ${{ inputs.disable_extra_builds == false }}
-        run: cargo build --examples --all-features --target=${{ inputs.target }}
+        run: cargo build --examples --all-features --target=${{ inputs.target }} ${{ steps.sysroot-deps.outputs.args }}
 
       - name: Build | build tests (default features)
         if: ${{ inputs.disable_extra_builds == false }}
-        run: cargo build --tests --target=${{ inputs.target }}
+        run: cargo build --tests --target=${{ inputs.target }} ${{ steps.sysroot-deps.outputs.args }}
 
       - name: Build | run tests (default features)
         if: ${{ inputs.disable_tests == false }}
-        run: cargo test --no-fail-fast --target=${{ inputs.target }}
+        run: cargo test --no-fail-fast --target=${{ inputs.target }} ${{ steps.sysroot-deps.outputs.args }}
 
       - name: Build | build tests (all features)
         if: ${{ inputs.disable_extra_builds == false }}
-        run: cargo build --tests --all-features --target=${{ inputs.target }}
+        run: cargo build --tests --all-features --target=${{ inputs.target }} ${{ steps.sysroot-deps.outputs.args }}
 
       - name: Build | run tests (all features)
         if: ${{ inputs.disable_tests == false }}
-        run: cargo test --no-fail-fast --all-features --target=${{ inputs.target }}
+        run: cargo test --no-fail-fast --all-features --target=${{ inputs.target }} ${{ steps.sysroot-deps.outputs.args }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -90,8 +90,7 @@ jobs:
             --allow-untrusted \
             --no-scripts \
             alpine-base ${{ inputs.extra_sysroot_packages }}
-          echo "PKG_CONFIG_SYSROOT_DIR=$PWD/sysroot" >> $GITHUB_ENV
-          echo "PKG_CONFIG_PATH=$PWD/sysroot/usr/lib/pkgconfig" >> $GITHUB_ENV
+          echo "PKG_CONFIG_PATH_${{ inputs.target }}=$PWD/sysroot/usr/lib/pkgconfig" >> $GITHUB_ENV
 
       - name: Build | add mingw32 to path
         if: inputs.runs_on == 'windows-2019'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -90,7 +90,7 @@ jobs:
             --allow-untrusted \
             --no-scripts \
             alpine-base ${{ inputs.extra_sysroot_packages }}
-          echo "args=--sysroot $PWD/sysroot" >> $GITHUB_OUTPUT
+          echo "PKG_CONFIG_SYSROOT_DIR=$PWD/sysroot" >> $GITHUB_ENV
 
       - name: Build | add mingw32 to path
         if: inputs.runs_on == 'windows-2019'
@@ -116,34 +116,34 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --target=${{ inputs.target }} ${{ steps.sysroot-deps.outputs.args }}
+          args: --target=${{ inputs.target }}
 
       - name: Build | build library (all features)
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --all-features --target=${{ inputs.target }} ${{ steps.sysroot-deps.outputs.args }}
+          args: --all-features --target=${{ inputs.target }}
 
       - name: Build | build examples (default features)
         if: ${{ inputs.disable_extra_builds == false }}
-        run: cargo build --examples --target=${{ inputs.target }} ${{ steps.sysroot-deps.outputs.args }}
+        run: cargo build --examples --target=${{ inputs.target }}
 
       - name: Build | build examples (all features)
         if: ${{ inputs.disable_extra_builds == false }}
-        run: cargo build --examples --all-features --target=${{ inputs.target }} ${{ steps.sysroot-deps.outputs.args }}
+        run: cargo build --examples --all-features --target=${{ inputs.target }}
 
       - name: Build | build tests (default features)
         if: ${{ inputs.disable_extra_builds == false }}
-        run: cargo build --tests --target=${{ inputs.target }} ${{ steps.sysroot-deps.outputs.args }}
+        run: cargo build --tests --target=${{ inputs.target }}
 
       - name: Build | run tests (default features)
         if: ${{ inputs.disable_tests == false }}
-        run: cargo test --no-fail-fast --target=${{ inputs.target }} ${{ steps.sysroot-deps.outputs.args }}
+        run: cargo test --no-fail-fast --target=${{ inputs.target }}
 
       - name: Build | build tests (all features)
         if: ${{ inputs.disable_extra_builds == false }}
-        run: cargo build --tests --all-features --target=${{ inputs.target }} ${{ steps.sysroot-deps.outputs.args }}
+        run: cargo build --tests --all-features --target=${{ inputs.target }}
 
       - name: Build | run tests (all features)
         if: ${{ inputs.disable_tests == false }}
-        run: cargo test --no-fail-fast --all-features --target=${{ inputs.target }} ${{ steps.sysroot-deps.outputs.args }}
+        run: cargo test --no-fail-fast --all-features --target=${{ inputs.target }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -65,7 +65,7 @@ jobs:
         if: contains(inputs.container, 'void-linux')
         run: |
           xbps-install -Syu || xbps-install -yu xbps
-          xbps-install -yu base-devel curl git ${{ inputs.extra_packages }}
+          xbps-install -yu base-devel bash curl git ${{ inputs.extra_packages }}
 
       - name: Build | add mingw32 to path
         if: inputs.runs_on == 'windows-2019'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -90,7 +90,7 @@ jobs:
             --allow-untrusted \
             --no-scripts \
             alpine-base ${{ inputs.extra_sysroot_packages }}
-          echo "PKG_CONFIG_PATH_${{ inputs.target }}=$PWD/sysroot/usr/lib/pkgconfig" >> $GITHUB_ENV
+          echo "PKG_CONFIG_SYSROOT_DIR_${{ inputs.target }}=$PWD/sysroot" >> $GITHUB_ENV
 
       - name: Build | add mingw32 to path
         if: inputs.runs_on == 'windows-2019'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -108,6 +108,7 @@ jobs:
     with:
       disable_tests: true
       extra_packages: cross-aarch64-linux-musl
+      extra_sysroot_packages: eudev-dev
       image: ghcr.io/void-linux/void-linux:latest-full-x86_64
       target: aarch64-unknown-linux-musl
 
@@ -149,6 +150,7 @@ jobs:
     uses: ./.github/workflows/build.yaml
     with:
       extra_packages: cross-i686-linux-musl
+      extra_sysroot_packages: eudev-dev
       image: ghcr.io/void-linux/void-linux:latest-full-x86_64
       target: i686-unknown-linux-musl
 
@@ -187,6 +189,7 @@ jobs:
     uses: ./.github/workflows/build.yaml
     with:
       extra_packages: cross-x86_64-linux-musl
+      extra_sysroot_packages: eudev-dev
       image: ghcr.io/void-linux/void-linux:latest-full-x86_64
       target: x86_64-unknown-linux-musl
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -107,7 +107,8 @@ jobs:
     uses: ./.github/workflows/build.yaml
     with:
       disable_tests: true
-      extra_packages: gcc-aarch64-linux-gnu
+      extra_packages: cross-aarch64-linux-musl
+      image: ghcr.io/void-linux/void-linux:latest-thin-bb-x86_64-musl
       target: aarch64-unknown-linux-musl
 
   arm-linux-androideabi:
@@ -147,7 +148,8 @@ jobs:
   i686-unknown-linux-musl:
     uses: ./.github/workflows/build.yaml
     with:
-      extra_packages: libudev-dev gcc-multilib
+      extra_packages: cross-i686-linux-musl
+      image: ghcr.io/void-linux/void-linux:latest-thin-bb-x86_64-musl
       target: i686-unknown-linux-musl
 
   x86_64-apple-darwin:
@@ -184,6 +186,8 @@ jobs:
   x86_64-unknown-linux-musl:
     uses: ./.github/workflows/build.yaml
     with:
+      extra_packages: eudev-libudev-devel
+      image: ghcr.io/void-linux/void-linux:latest-thin-bb-x86_64-musl
       target: x86_64-unknown-linux-musl
 
   x86_64-unknown-netbsd:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -108,7 +108,7 @@ jobs:
     with:
       disable_tests: true
       extra_packages: cross-aarch64-linux-musl
-      image: ghcr.io/void-linux/void-linux:latest-thin-bb-x86_64-musl
+      image: ghcr.io/void-linux/void-linux:latest-thin-bb-x86_64
       target: aarch64-unknown-linux-musl
 
   arm-linux-androideabi:
@@ -149,7 +149,7 @@ jobs:
     uses: ./.github/workflows/build.yaml
     with:
       extra_packages: cross-i686-linux-musl
-      image: ghcr.io/void-linux/void-linux:latest-thin-bb-x86_64-musl
+      image: ghcr.io/void-linux/void-linux:latest-thin-bb-x86_64
       target: i686-unknown-linux-musl
 
   x86_64-apple-darwin:
@@ -186,8 +186,8 @@ jobs:
   x86_64-unknown-linux-musl:
     uses: ./.github/workflows/build.yaml
     with:
-      extra_packages: eudev-libudev-devel
-      image: ghcr.io/void-linux/void-linux:latest-thin-bb-x86_64-musl
+      extra_packages: cross-x86_64-linux-musl
+      image: ghcr.io/void-linux/void-linux:latest-thin-bb-x86_64
       target: x86_64-unknown-linux-musl
 
   x86_64-unknown-netbsd:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -108,7 +108,7 @@ jobs:
     with:
       disable_tests: true
       extra_packages: cross-aarch64-linux-musl
-      image: ghcr.io/void-linux/void-linux:latest-thin-bb-x86_64
+      image: ghcr.io/void-linux/void-linux:latest-full-x86_64
       target: aarch64-unknown-linux-musl
 
   arm-linux-androideabi:
@@ -149,7 +149,7 @@ jobs:
     uses: ./.github/workflows/build.yaml
     with:
       extra_packages: cross-i686-linux-musl
-      image: ghcr.io/void-linux/void-linux:latest-thin-bb-x86_64
+      image: ghcr.io/void-linux/void-linux:latest-full-x86_64
       target: i686-unknown-linux-musl
 
   x86_64-apple-darwin:
@@ -187,7 +187,7 @@ jobs:
     uses: ./.github/workflows/build.yaml
     with:
       extra_packages: cross-x86_64-linux-musl
-      image: ghcr.io/void-linux/void-linux:latest-thin-bb-x86_64
+      image: ghcr.io/void-linux/void-linux:latest-full-x86_64
       target: x86_64-unknown-linux-musl
 
   x86_64-unknown-netbsd:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ bitflags = ">=1.3.1, <2.1.0"
 cfg-if = "1.0.0"
 nix = { version = "0.26", default-features = false, features = ["fs", "ioctl", "poll", "signal", "term"] }
 
-[target.'cfg(all(target_os = "linux", not(target_env = "musl")))'.dependencies]
+[target.'cfg(target_os = "linux")'.dependencies]
 libudev = { version = "0.3.0", optional = true }
 
 [target.'cfg(any(target_os = "ios", target_os = "macos"))'.dependencies]

--- a/src/posix/enumerate.rs
+++ b/src/posix/enumerate.rs
@@ -1,6 +1,6 @@
 #[cfg(any(target_os = "ios", target_os = "macos"))]
 use nix::libc::{c_char, c_void};
-#[cfg(all(target_os = "linux", not(target_env = "musl"), feature = "libudev"))]
+#[cfg(all(target_os = "linux", feature = "libudev"))]
 use std::ffi::OsStr;
 #[cfg(any(target_os = "ios", target_os = "macos"))]
 use std::ffi::{CStr, CString};
@@ -22,14 +22,14 @@ use IOKit_sys::*;
 use crate::SerialPortType;
 #[cfg(any(
     target_os = "ios",
-    all(target_os = "linux", not(target_env = "musl"), feature = "libudev"),
+    all(target_os = "linux", feature = "libudev"),
     target_os = "macos"
 ))]
 use crate::UsbPortInfo;
 #[cfg(any(
     target_os = "android",
     target_os = "ios",
-    all(target_os = "linux", not(target_env = "musl"), feature = "libudev"),
+    all(target_os = "linux", feature = "libudev"),
     target_os = "macos",
     target_os = "netbsd",
     target_os = "openbsd",
@@ -39,7 +39,7 @@ use crate::{Result, SerialPortInfo};
 
 /// Retrieves the udev property value named by `key`. If the value exists, then it will be
 /// converted to a String, otherwise None will be returned.
-#[cfg(all(target_os = "linux", not(target_env = "musl"), feature = "libudev"))]
+#[cfg(all(target_os = "linux", feature = "libudev"))]
 fn udev_property_as_string(d: &libudev::Device, key: &str) -> Option<String> {
     d.property_value(key)
         .and_then(OsStr::to_str)
@@ -52,7 +52,7 @@ fn udev_property_as_string(d: &libudev::Device, key: &str) -> Option<String> {
 /// will be returned.
 /// This function uses a built-in type's `from_str_radix` to implementation to perform the
 /// actual conversion.
-#[cfg(all(target_os = "linux", not(target_env = "musl"), feature = "libudev"))]
+#[cfg(all(target_os = "linux", feature = "libudev"))]
 fn udev_hex_property_as_int<T>(
     d: &libudev::Device,
     key: &str,
@@ -69,7 +69,7 @@ fn udev_hex_property_as_int<T>(
     }
 }
 
-#[cfg(all(target_os = "linux", not(target_env = "musl"), feature = "libudev"))]
+#[cfg(all(target_os = "linux", feature = "libudev"))]
 fn port_type(d: &libudev::Device) -> Result<SerialPortType> {
     match d.property_value("ID_BUS").and_then(OsStr::to_str) {
         Some("usb") => {
@@ -395,7 +395,7 @@ cfg_if! {
             }
             Ok(vec)
         }
-    } else if #[cfg(all(target_os = "linux", not(target_env = "musl"), feature = "libudev"))] {
+    } else if #[cfg(all(target_os = "linux", feature = "libudev"))] {
         /// Scans the system for serial ports and returns a list of them.
         /// The `SerialPortInfo` struct contains the name of the port
         /// which can be used for opening it.

--- a/src/posix/error.rs
+++ b/src/posix/error.rs
@@ -2,7 +2,7 @@ use std::io;
 
 use crate::{Error, ErrorKind};
 
-#[cfg(all(target_os = "linux", not(target_env = "musl"), feature = "libudev"))]
+#[cfg(all(target_os = "linux", feature = "libudev"))]
 impl From<libudev::Error> for Error {
     fn from(e: libudev::Error) -> Error {
         use libudev::ErrorKind as K;

--- a/src/posix/ioctl.rs
+++ b/src/posix/ioctl.rs
@@ -51,11 +51,7 @@ mod raw {
             target_os = "android",
             all(
                 target_os = "linux",
-                not(any(
-                    target_env = "musl",
-                    target_arch = "powerpc",
-                    target_arch = "powerpc64"
-                ))
+                not(any(target_arch = "powerpc", target_arch = "powerpc64"))
             )
         ))]
         tcgets2,
@@ -68,11 +64,7 @@ mod raw {
             target_os = "android",
             all(
                 target_os = "linux",
-                not(any(
-                    target_env = "musl",
-                    target_arch = "powerpc",
-                    target_arch = "powerpc64"
-                ))
+                not(any(target_arch = "powerpc", target_arch = "powerpc64"))
             )
         ))]
         tcsets2,
@@ -167,11 +159,7 @@ pub fn tiocmbis(fd: RawFd, status: SerialLines) -> Result<()> {
     target_os = "android",
     all(
         target_os = "linux",
-        not(any(
-            target_env = "musl",
-            target_arch = "powerpc",
-            target_arch = "powerpc64"
-        ))
+        not(any(target_arch = "powerpc", target_arch = "powerpc64"))
     )
 ))]
 pub fn tcgets2(fd: RawFd) -> Result<libc::termios2> {
@@ -186,11 +174,7 @@ pub fn tcgets2(fd: RawFd) -> Result<libc::termios2> {
     target_os = "android",
     all(
         target_os = "linux",
-        not(any(
-            target_env = "musl",
-            target_arch = "powerpc",
-            target_arch = "powerpc64"
-        ))
+        not(any(target_arch = "powerpc", target_arch = "powerpc64"))
     )
 ))]
 pub fn tcsets2(fd: RawFd, options: &libc::termios2) -> Result<()> {

--- a/src/posix/termios.rs
+++ b/src/posix/termios.rs
@@ -17,7 +17,6 @@ cfg_if! {
         all(
             target_os = "linux",
             any(
-                target_env = "musl",
                 target_arch = "powerpc",
                 target_arch = "powerpc64"
             )
@@ -29,7 +28,6 @@ cfg_if! {
         all(
             target_os = "linux",
             not(any(
-                target_env = "musl",
                 target_arch = "powerpc",
                 target_arch = "powerpc64"
             ))
@@ -65,11 +63,7 @@ pub(crate) fn get_termios(fd: RawFd) -> Result<Termios> {
     target_os = "openbsd",
     all(
         target_os = "linux",
-        any(
-            target_env = "musl",
-            target_arch = "powerpc",
-            target_arch = "powerpc64"
-        )
+        any(target_arch = "powerpc", target_arch = "powerpc64")
     )
 ))]
 pub(crate) fn get_termios(fd: RawFd) -> Result<Termios> {
@@ -85,11 +79,7 @@ pub(crate) fn get_termios(fd: RawFd) -> Result<Termios> {
     target_os = "android",
     all(
         target_os = "linux",
-        not(any(
-            target_env = "musl",
-            target_arch = "powerpc",
-            target_arch = "powerpc64"
-        ))
+        not(any(target_arch = "powerpc", target_arch = "powerpc64"))
     )
 ))]
 pub(crate) fn get_termios(fd: RawFd) -> Result<Termios> {
@@ -117,11 +107,7 @@ pub(crate) fn set_termios(fd: RawFd, termios: &libc::termios, baud_rate: u32) ->
     target_os = "openbsd",
     all(
         target_os = "linux",
-        any(
-            target_env = "musl",
-            target_arch = "powerpc",
-            target_arch = "powerpc64"
-        )
+        any(target_arch = "powerpc", target_arch = "powerpc64")
     )
 ))]
 pub(crate) fn set_termios(fd: RawFd, termios: &libc::termios) -> Result<()> {
@@ -134,11 +120,7 @@ pub(crate) fn set_termios(fd: RawFd, termios: &libc::termios) -> Result<()> {
     target_os = "android",
     all(
         target_os = "linux",
-        not(any(
-            target_env = "musl",
-            target_arch = "powerpc",
-            target_arch = "powerpc64"
-        ))
+        not(any(target_arch = "powerpc", target_arch = "powerpc64"))
     )
 ))]
 pub(crate) fn set_termios(fd: RawFd, termios: &Termios) -> Result<()> {
@@ -206,11 +188,7 @@ pub(crate) fn set_stop_bits(termios: &mut Termios, stop_bits: StopBits) {
     target_os = "android",
     all(
         target_os = "linux",
-        not(any(
-            target_env = "musl",
-            target_arch = "powerpc",
-            target_arch = "powerpc64"
-        ))
+        not(any(target_arch = "powerpc", target_arch = "powerpc64"))
     )
 ))]
 pub(crate) fn set_baud_rate(termios: &mut Termios, baud_rate: u32) {
@@ -234,11 +212,7 @@ pub(crate) fn set_baud_rate(termios: &mut Termios, baud_rate: u32) {
 
 #[cfg(all(
     target_os = "linux",
-    any(
-        target_env = "musl",
-        target_arch = "powerpc",
-        target_arch = "powerpc64"
-    )
+    any(target_arch = "powerpc", target_arch = "powerpc64")
 ))]
 pub(crate) fn set_baud_rate(termios: &mut Termios, baud_rate: u32) {
     use self::libc::{

--- a/src/posix/tty.rs
+++ b/src/posix/tty.rs
@@ -446,11 +446,7 @@ impl SerialPort for TTYPort {
         target_os = "android",
         all(
             target_os = "linux",
-            not(any(
-                target_env = "musl",
-                target_arch = "powerpc",
-                target_arch = "powerpc64"
-            ))
+            not(any(target_arch = "powerpc", target_arch = "powerpc64"))
         )
     ))]
     fn baud_rate(&self) -> Result<u32> {
@@ -497,11 +493,7 @@ impl SerialPort for TTYPort {
     /// desired baud rate.
     #[cfg(all(
         target_os = "linux",
-        any(
-            target_env = "musl",
-            target_arch = "powerpc",
-            target_arch = "powerpc64"
-        )
+        any(target_arch = "powerpc", target_arch = "powerpc64")
     ))]
     fn baud_rate(&self) -> Result<u32> {
         use self::libc::{

--- a/tests/test_tty.rs
+++ b/tests/test_tty.rs
@@ -135,14 +135,7 @@ fn test_ttyport_set_standard_baud() {
 
 // On mac this fails because you can't set nonstandard baud rates for these virtual ports
 #[test]
-#[cfg_attr(
-    any(
-        target_os = "ios",
-        all(target_os = "linux", target_env = "musl"),
-        target_os = "macos"
-    ),
-    ignore
-)]
+#[cfg_attr(any(target_os = "ios", target_os = "macos"), ignore)]
 fn test_ttyport_set_nonstandard_baud() {
     // `master` must be used here as Dropping it causes slave to be deleted by the OS.
     // TODO: Convert this to a statement-level attribute once


### PR DESCRIPTION
udev is a typical way of handling devices on musl-based distributions as well. there is no reason to handle this differently than on gnu libc distros.