### PR TITLE
Bring hardware_check.rs back into service

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ scopeguard = "1.1"
 serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
+assert_hex = "0.2.2"
 clap = { version = "3.1.6", features = ["derive"] }
 
 [features]

--- a/examples/hardware_check.rs
+++ b/examples/hardware_check.rs
@@ -269,10 +269,15 @@ fn test_single_port(port: &mut dyn serialport::SerialPort, loopback: bool) {
 }
 
 fn check_test_message(sender: &mut dyn SerialPort, receiver: &mut dyn SerialPort) {
+    // Ignore any "residue" from previous tests.
+    sender.clear(ClearBuffer::All).unwrap();
+    receiver.clear(ClearBuffer::All).unwrap();
+
     let send_buf = TEST_MESSAGE;
     let mut recv_buf = [0u8; TEST_MESSAGE.len()];
 
     sender.write_all(send_buf).unwrap();
+    sender.flush().unwrap();
 
     match receiver.read_exact(&mut recv_buf) {
         Ok(()) => {

--- a/examples/hardware_check.rs
+++ b/examples/hardware_check.rs
@@ -282,7 +282,7 @@ fn check_test_message(sender: &mut dyn SerialPort, receiver: &mut dyn SerialPort
     match receiver.read_exact(&mut recv_buf) {
         Ok(()) => {
             assert_eq_hex!(recv_buf, send_buf, "Received message does not match sent",);
-            println!("success");
+            println!("        success");
         }
         Err(e) => println!("FAILED: {:?}", e),
     }
@@ -307,45 +307,50 @@ fn test_dual_ports(port1: &mut dyn serialport::SerialPort, port2: &mut dyn seria
     );
 
     let baud_rate = 2_000_000;
-    print!("     At {},8,n,1,noflow...", baud_rate);
+    println!("     At {},8,n,1,noflow...", baud_rate);
     std::io::stdout().flush().unwrap();
     if port1.set_baud_rate(baud_rate).is_ok() && port2.set_baud_rate(baud_rate).is_ok() {
         check_test_message(port1, port2);
+        check_test_message(port2, port1);
     } else {
         println!("FAILED (does this platform & port support arbitrary baud rates?)");
     }
 
     let baud_rate = 115_200;
-    print!("     At {},8,n,1,noflow...", baud_rate);
+    println!("     At {},8,n,1,noflow...", baud_rate);
     std::io::stdout().flush().unwrap();
     if port1.set_baud_rate(baud_rate).is_ok() && port2.set_baud_rate(baud_rate).is_ok() {
         check_test_message(port1, port2);
+        check_test_message(port2, port1);
     } else {
         println!("FAILED");
     }
 
     let baud_rate = 57_600;
-    print!("     At {},8,n,1,noflow...", baud_rate);
+    println!("     At {},8,n,1,noflow...", baud_rate);
     std::io::stdout().flush().unwrap();
     if port1.set_baud_rate(baud_rate).is_ok() && port2.set_baud_rate(baud_rate).is_ok() {
         check_test_message(port1, port2);
+        check_test_message(port2, port1);
     } else {
         println!("FAILED");
     }
 
     let baud_rate = 10_000;
-    print!("     At {},8,n,1,noflow...", baud_rate);
+    println!("     At {},8,n,1,noflow...", baud_rate);
     std::io::stdout().flush().unwrap();
     if port1.set_baud_rate(baud_rate).is_ok() && port2.set_baud_rate(baud_rate).is_ok() {
         check_test_message(port1, port2);
+        check_test_message(port2, port1);
     } else {
         println!("FAILED (does this platform & port support arbitrary baud rates?)");
     }
     let baud_rate = 9600;
-    print!("     At {},8,n,1,noflow...", baud_rate);
+    println!("     At {},8,n,1,noflow...", baud_rate);
     std::io::stdout().flush().unwrap();
     if port1.set_baud_rate(baud_rate).is_ok() && port2.set_baud_rate(baud_rate).is_ok() {
         check_test_message(port1, port2);
+        check_test_message(port2, port1);
     } else {
         println!("FAILED");
     }
@@ -353,15 +358,17 @@ fn test_dual_ports(port1: &mut dyn serialport::SerialPort, port2: &mut dyn seria
     // Test flow control
     port1.set_flow_control(FlowControl::Software).unwrap();
     port2.set_flow_control(FlowControl::Software).unwrap();
-    print!("     At 9600,8,n,1,softflow...");
+    println!("     At 9600,8,n,1,softflow...");
     std::io::stdout().flush().unwrap();
     check_test_message(port1, port2);
+    check_test_message(port2, port1);
 
     port1.set_flow_control(FlowControl::Hardware).unwrap();
     port2.set_flow_control(FlowControl::Hardware).unwrap();
-    print!("     At 9600,8,n,1,hardflow...");
+    println!("     At 9600,8,n,1,hardflow...");
     std::io::stdout().flush().unwrap();
     check_test_message(port1, port2);
+    check_test_message(port2, port1);
 }
 
 fn set_defaults(port: &mut dyn serialport::SerialPort) {

--- a/examples/hardware_check.rs
+++ b/examples/hardware_check.rs
@@ -370,5 +370,7 @@ fn set_defaults(port: &mut dyn serialport::SerialPort) {
     port.set_flow_control(FlowControl::Software).unwrap();
     port.set_parity(Parity::None).unwrap();
     port.set_stop_bits(StopBits::One).unwrap();
-    port.set_timeout(Duration::from_millis(0)).unwrap();
+    // TODO: Clean up timeouts and use a less-arbitrary value here. The previous timeout of 0 made
+    // test_dual_ports fail due to a timeout where having at least some some made them pass.
+    port.set_timeout(Duration::from_millis(1000)).unwrap();
 }


### PR DESCRIPTION
I did not manage to run `hardware_check.rs` on Linux and macOS because the tests failed due to missing or wrong received data. This happened due to reading with a timeout of zero and not clearing already received data from previous test cases. This is one small step for #106.

This PR addresses these two by:

* Clearing send and receive buffer at the beginning of each test case
* Explicitly flushing output data before reading to ensure that all data has been on the wire at this point in time
* Setting a timeout greater than zero (with 10 ms the tests still felt flaky, and 1,000 ms should give enough timing safety margin as we still have no way to disable timeouts completely yet)

It also includes the following additions:

* Factoring out the actual test routine into an individual function for reuse
* Making assertions on buffer data/bytes instead of strings for always showing the received data in case of an assertion error and not bailing out from invalid UTF-8
* Using the assert_hex crate for assertions on buffer contents
* Transmitting the test message back and forth instead only in one direction

Successfully ran the tests on Linux, macOS, and Windows.