### PR TITLE
 Fixes the PCI-port bug on Raspberry Pi 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 ### Changed
 ### Fixed
+* Fixes a bug on the Raspberry Pi 4, which results in USB-devices being detected as PCI-devices.
+  [#110]
+
 ### Removed
 
 ## [4.2.1] - 2023-05-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ project adheres to [Semantic Versioning](https://semver.org/).
 ### Changed
 ### Fixed
 * Fixes a bug on the Raspberry Pi 4, which results in USB-devices being detected as PCI-devices.
-  [#110]
+  [#113](https://github.com/serialport/serialport-rs/pull/113)
 
 ### Removed
 

--- a/src/posix/enumerate.rs
+++ b/src/posix/enumerate.rs
@@ -71,12 +71,6 @@ fn udev_hex_property_as_int<T>(
 
 #[cfg(all(target_os = "linux", not(target_env = "musl"), feature = "libudev"))]
 fn port_type(d: &libudev::Device) -> Result<SerialPortType> {
-    let properties: Vec<String> = d
-        .properties()
-        .map(|p| format!("{:?} = {:?}, ", p.name(), p.value()))
-        .collect();
-    log::trace!("port_type: properties: {:#?}", properties);
-
     match d.property_value("ID_BUS").and_then(OsStr::to_str) {
         Some("usb") => {
             let serial_number = udev_property_as_string(d, "ID_SERIAL_SHORT");

--- a/src/posix/enumerate.rs
+++ b/src/posix/enumerate.rs
@@ -109,7 +109,7 @@ fn port_type(d: &libudev::Device) -> Result<SerialPortType> {
                         d,
                         "ID_USB_INTERFACE_NUM",
                         &u8::from_str_radix,
-                    )?
+                    )
                     .ok(),
                 }))
             } else {


### PR DESCRIPTION
The Bug is caused by the Fact that the USB controller is connected to
the CPU via PCI, which was not the case on the Raspberry Pi 3.
Because of this, the BUS_ID reported by libudev is PCI. However, if it
is an actual USB device, there will be fields containing the neccessary
information to generate a UsbPortInfo. This patch checks whether all
those fields are available, if the BUS_ID is Pci, and if so uses them to
populate an UsbPortInfo and return a SerialPortType::UsbPort

Fixes #110