### PR TITLE
Report actual device file on Linux without udev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 ### Changed
 ### Fixed
+
+* Fixes a bug on Linux without udev where `available_ports()` returned wrong
+  device file paths.
+  [#122](https://github.com/serialport/serialport-rs/pull/122)
+
 ### Removed
 
 ## [4.2.2] - 2023-08-03


### PR DESCRIPTION
This addresses #66 by returning he expected device file paths instead the paths from `/sys/class/tty`.