### PR TITLE
Swap out unmaintained dependencies for apple-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ nix = { version = "0.26", default-features = false, features = ["fs", "ioctl", "
 libudev = { version = "0.3.0", optional = true }
 
 [target.'cfg(any(target_os = "ios", target_os = "macos"))'.dependencies]
-apple-sys = { version = "0.2.0", features = ["CoreFoundation", "IOKit"] }
+apple-sys = { git = "https://github.com/tommy-gilligan/apple-sys.git", features = ["CoreFoundation", "IOKit"] }
 mach2 = "0.4.1"
 
 [target."cfg(windows)".dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,7 @@ nix = { version = "0.26", default-features = false, features = ["fs", "ioctl", "
 libudev = { version = "0.3.0", optional = true }
 
 [target.'cfg(any(target_os = "ios", target_os = "macos"))'.dependencies]
-CoreFoundation-sys = "0.1.4"
-IOKit-sys = "0.1.5"
+apple-sys = { version = "0.2.0", features = ["CoreFoundation", "IOKit"] }
 mach2 = "0.4.1"
 
 [target."cfg(windows)".dependencies]

--- a/deny.toml
+++ b/deny.toml
@@ -83,6 +83,8 @@ allow = [
     "Apache-2.0",
     "Unicode-DFS-2016",
     "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
 ]
 # List of explicitly disallowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses

--- a/deny.toml
+++ b/deny.toml
@@ -50,7 +50,6 @@ notice = "deny"
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
-    "RUSTSEC-2020-0168", # caused by unmaintained mach dependency of core-foundation-sys
     "RUSTSEC-2021-0145", # caused by unmaintained atty
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score


### PR DESCRIPTION
This deals with #112 

There's probably a way to avoid casting between pointers types.  Any suggestions appreciated.

Not sure why `IORegistryEntryGetParentEntry` needs `plane` argument to be `mut` here. 
https://developer.apple.com/documentation/iokit/1514454-ioregistryentrygetparententry
This is maybe an `apple-sys` issue?
```
-            IORegistryEntryGetParentEntry(device, kIOServiceClass(), parent.as_mut_ptr())
-                != KERN_SUCCESS
+            IORegistryEntryGetParentEntry(
+                device,
+                kIOServiceClass.as_ptr() as *mut i8,
+                parent.as_mut_ptr(),
+            ) != KERN_SUCCESS
```