### PR TITLE
Update bitflags dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 ### Added
 ### Changed
+
+* Update `bitflags` dependency to 2.4.0.
+  [#127](https://github.com/serialport/serialport-rs/pull/127)
+
 ### Fixed
 
 * Fixes a bug on Linux without udev where `available_ports()` returned wrong

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["serial", "hardware", "system", "RS232"]
 categories = ["hardware-support"]
 
 [target."cfg(unix)".dependencies]
-bitflags = ">=1.3.1, <2.1.0"
+bitflags = "2.4.0"
 cfg-if = "1.0.0"
 nix = { version = "0.26", default-features = false, features = ["fs", "ioctl", "poll", "signal", "term"] }
 


### PR DESCRIPTION
Limiting bitflags to <2.1.0 causes compatibility issues and build failures with other crates, e.g:

error: failed to select a version for `bitflags`.
    ... required by package `bindgen v0.68.1`
    ... which satisfies dependency `bindgen = "^0.68.1"` of package ...
versions that meet the requirements `^2.2.1` are: 2.4.0, 2.3.3, 2.3.2, 2.3.1, 2.3.0, 2.2.1

all possible versions conflict with previously selected packages.

  previously selected package `bitflags v2.0.2`
    ... which satisfies dependency `bitflags = ">=1.3.1, <2.1.0"` (locked to 2.0.2) of package `serialport v4.2.2`
    ... which satisfies dependency `serialport = "^4.2.2"` (locked to 4.2.2) of package ...

failed to select a version for `bitflags` which could resolve this conflict