### PR TITLE
open with O_CLOEXEC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ project adheres to [Semantic Versioning](https://semver.org/).
 
 * Update `bitflags` dependency to 2.4.0.
   [#127](https://github.com/serialport/serialport-rs/pull/127)
+- Open serial devices with `O_CLOEXEC` (Posix). This will close the device
+  handles when starting a child process. In particular this means that a serial
+  device can be reopened after making SW update of a Tauri application.
+  [#130](https://github.com/serialport/serialport-rs/pull/130)
 
 ### Fixed
 

--- a/src/posix/tty.rs
+++ b/src/posix/tty.rs
@@ -116,7 +116,7 @@ impl TTYPort {
         let path = Path::new(&builder.path);
         let fd = OwnedFd(nix::fcntl::open(
             path,
-            OFlag::O_RDWR | OFlag::O_NOCTTY | OFlag::O_NONBLOCK,
+            OFlag::O_RDWR | OFlag::O_NOCTTY | OFlag::O_NONBLOCK | OFlag::O_CLOEXEC,
             nix::sys::stat::Mode::empty(),
         )?);
 
@@ -344,7 +344,7 @@ impl TTYPort {
     ///
     /// This function returns an error if the serial port couldn't be cloned.
     pub fn try_clone_native(&self) -> Result<TTYPort> {
-        let fd_cloned: i32 = fcntl(self.fd, nix::fcntl::F_DUPFD(self.fd))?;
+        let fd_cloned: i32 = fcntl(self.fd, nix::fcntl::F_DUPFD_CLOEXEC(self.fd))?;
         Ok(TTYPort {
             fd: fd_cloned,
             exclusive: self.exclusive,


### PR DESCRIPTION
This fixes a problem with Tauri auto update: After updating the tauri application it is restarted, but the serial files were not closed, and therefore the application could not open them again.

With this flag the files are closed when executing `execve()` to start the new application instance.

Change-Id: I102ba33411135a8e89e3203f9dad910d385feeee