### PR TITLE
Fix serial number reporting on Windows for some devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ project adheres to [Semantic Versioning](https://semver.org/).
 * Fixes a bug on Linux without udev where `available_ports()` returned wrong
   device file paths.
   [#122](https://github.com/serialport/serialport-rs/pull/122)
+* Fixes a bug on Windows where some USB device serial numbers were truncated.
+  [#131](https://github.com/serialport/serialport-rs/pull/131)
 
 ### Removed
 

--- a/src/windows/dcb.rs
+++ b/src/windows/dcb.rs
@@ -11,9 +11,9 @@ pub(crate) fn get_dcb(handle: HANDLE) -> Result<DCB> {
     dcb.DCBlength = std::mem::size_of::<DCB>() as u32;
 
     if unsafe { GetCommState(handle, &mut dcb) } != 0 {
-        return Ok(dcb);
+        Ok(dcb)
     } else {
-        return Err(super::error::last_os_error());
+        Err(super::error::last_os_error())
     }
 }
 
@@ -57,9 +57,9 @@ pub(crate) fn init(dcb: &mut DCB) {
 
 pub(crate) fn set_dcb(handle: HANDLE, mut dcb: DCB) -> Result<()> {
     if unsafe { SetCommState(handle, &mut dcb as *mut _) != 0 } {
-        return Ok(());
+        Ok(())
     } else {
-        return Err(super::error::last_os_error());
+        Err(super::error::last_os_error())
     }
 }
 
@@ -78,9 +78,9 @@ pub(crate) fn set_data_bits(dcb: &mut DCB, data_bits: DataBits) {
 
 pub(crate) fn set_parity(dcb: &mut DCB, parity: Parity) {
     dcb.Parity = match parity {
-        Parity::None => NOPARITY as u8,
-        Parity::Odd => ODDPARITY as u8,
-        Parity::Even => EVENPARITY as u8,
+        Parity::None => NOPARITY,
+        Parity::Odd => ODDPARITY,
+        Parity::Even => EVENPARITY,
     };
 
     dcb.set_fParity(if parity == Parity::None { FALSE } else { TRUE } as DWORD);
@@ -88,8 +88,8 @@ pub(crate) fn set_parity(dcb: &mut DCB, parity: Parity) {
 
 pub(crate) fn set_stop_bits(dcb: &mut DCB, stop_bits: StopBits) {
     dcb.StopBits = match stop_bits {
-        StopBits::One => ONESTOPBIT as u8,
-        StopBits::Two => TWOSTOPBITS as u8,
+        StopBits::One => ONESTOPBIT,
+        StopBits::Two => TWOSTOPBITS,
     };
 }
 

--- a/src/windows/enumerate.rs
+++ b/src/windows/enumerate.rs
@@ -280,10 +280,8 @@ impl PortDevice {
             )
         };
 
-        if res == FALSE {
-            if unsafe { GetLastError() } != ERROR_INSUFFICIENT_BUFFER {
-                return None;
-            }
+        if res == FALSE && unsafe { GetLastError() } != ERROR_INSUFFICIENT_BUFFER {
+            return None;
         }
 
         // Using the unicode version of 'SetupDiGetDeviceRegistryProperty' seems to report the
@@ -317,7 +315,7 @@ pub fn available_ports() -> Result<Vec<SerialPortInfo>> {
             }
 
             ports.push(SerialPortInfo {
-                port_name: port_name,
+                port_name,
                 port_type: port_device.port_type(),
             });
         }


### PR DESCRIPTION
Some devices have their serial numbers misreported. For example, the BMP device `USB\VID_1D50&PID_6018&MI_02\6&A694CA9&0&0000` gets a reported serial number of `6` rather than `A694CA9`.

Fix this and update the testcase.