### PR TITLE
Use maintained sys crates for CoreFoundation and IOKit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ project adheres to [Semantic Versioning](https://semver.org/).
   [#122](https://github.com/serialport/serialport-rs/pull/122)
 * Fixes a bug on Windows where some USB device serial numbers were truncated.
   [#131](https://github.com/serialport/serialport-rs/pull/131)
+* Switches to maintained sys crates for CoreFoundation and IOKit on macOS.
+  [#112](https://github.com/serialport/serialport-rs/issues/112),
+  [#136](https://github.com/serialport/serialport-rs/pull/136)
 
 ### Removed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ nix = { version = "0.26", default-features = false, features = ["fs", "ioctl", "
 libudev = { version = "0.3.0", optional = true }
 
 [target.'cfg(any(target_os = "ios", target_os = "macos"))'.dependencies]
-CoreFoundation-sys = "0.1.4"
-IOKit-sys = "0.1.5"
+core-foundation-sys = "0.8.4"
+io-kit-sys = "0.4.0"
 mach2 = "0.4.1"
 
 [target."cfg(windows)".dependencies]


### PR DESCRIPTION
* This is an alternative to #135 which uses creates where the actual code is in the repository and not generated during build time
* Fixes #112
* This PR drive-by fixes the use of `CFDictionaryGet` and `CFGetTypeID`
    * The former could return a `NULL` pointer which [does not seem to be accepted by `CFGetTypeID`](https://github.com/opensource-apple/CF/blob/3cc41a76b1491f50813e28a4ec09954ffa359e6f/CFRuntime.c#L500) by switching to `CFDictionaryGetIfPresent`
    * Using `CFDictionaryGetIfPresent` also allow us to use the already released versions of core-foundation-sys and io-kit and not wait for upcomming releases (like https://github.com/servo/core-foundation-rs/issues/645)