### PR TITLE
Prefer manufacturer and model information from device over udev database

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,7 +56,7 @@ jobs:
       disable_tests: true
       extra_packages: libudev-dev
       target: x86_64-unknown-linux-gnu
-      toolchain: "1.56.1"
+      toolchain: "1.59.0"
 
   # --------------------------------------------------------------------------
   # cargo-deny

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,14 +48,66 @@ jobs:
 
   # --------------------------------------------------------------------------
   # MSRV
+  #
+  # Check at least once per platform.
 
-  msrv:
+  msrv-aarch64-apple-darwin:
+    uses: ./.github/workflows/build.yaml
+    with:
+      disable_extra_builds: true
+      disable_tests: true
+      target: aarch64-apple-darwin
+      toolchain: "1.59.0"
+
+  msrv-arm-linux-androideabi:
+    uses: ./.github/workflows/build.yaml
+    with:
+      disable_extra_builds: true
+      disable_tests: true
+      target: arm-linux-androideabi
+      toolchain: "1.59.0"
+
+  msrv-x86_64-unknown-freebsd:
+    uses: ./.github/workflows/build.yaml
+    with:
+      disable_extra_builds: true
+      disable_tests: true
+      target: x86_64-unknown-freebsd
+      toolchain: "1.59.0"
+
+  msrv-x86_64-unknown-linux-gnu:
     uses: ./.github/workflows/build.yaml
     with:
       disable_extra_builds: true
       disable_tests: true
       extra_packages: libudev-dev
       target: x86_64-unknown-linux-gnu
+      toolchain: "1.59.0"
+
+  msrv-x86_64-unknown-linux-musl:
+    uses: ./.github/workflows/build.yaml
+    with:
+      disable_extra_builds: true
+      disable_tests: true
+      extra_packages: gcc-aarch64-linux-gnu
+      target: aarch64-unknown-linux-musl
+      toolchain: "1.59.0"
+
+  msrv-x86_64-pc-windows-msvc:
+    uses: ./.github/workflows/build.yaml
+    with:
+      disable_extra_builds: true
+      disable_tests: true
+      runs_on: windows-2019
+      target: x86_64-pc-windows-msvc
+      toolchain: "1.59.0"
+
+  msrv-x86_64-unknown-netbsd:
+    uses: ./.github/workflows/build.yaml
+    with:
+      disable_extra_builds: true
+      disable_tests: true
+      target: x86_64-unknown-netbsd
       toolchain: "1.59.0"
 
   # --------------------------------------------------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ project adheres to [Semantic Versioning](https://semver.org/).
   handles when starting a child process. In particular this means that a serial
   device can be reopened after making SW update of a Tauri application.
   [#130](https://github.com/serialport/serialport-rs/pull/130)
+* Prefer USB device manufacturer and model information from the actual USB
+  device over the information from udev's database.
+  [#137](https://github.com/serialport/serialport-rs/pull/137)
+* Raise MSRV from 1.56.1 to 1.59.0.
+  [#137](https://github.com/serialport/serialport-rs/pull/137)
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ nix = { version = "0.26", default-features = false, features = ["fs", "ioctl", "
 
 [target.'cfg(all(target_os = "linux", not(target_env = "musl")))'.dependencies]
 libudev = { version = "0.3.0", optional = true }
-unescape = "0.1.0"
+unescaper = "0.1.3"
 
 [target.'cfg(any(target_os = "ios", target_os = "macos"))'.dependencies]
 core-foundation-sys = "0.8.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ nix = { version = "0.26", default-features = false, features = ["fs", "ioctl", "
 
 [target.'cfg(all(target_os = "linux", not(target_env = "musl")))'.dependencies]
 libudev = { version = "0.3.0", optional = true }
+unescape = "0.1.0"
 
 [target.'cfg(any(target_os = "ios", target_os = "macos"))'.dependencies]
 core-foundation-sys = "0.8.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,8 @@ authors = [
     "Bryant Mairs <bryant@mai.rs>",
     "Jesse Braham <jesse@beta7.io>",
 ]
-edition = "2018"
-rust-version = "1.56.1"
+edition = "2021"
+rust-version = "1.59.0"
 description = "A cross-platform low-level serial port library."
 documentation = "https://docs.rs/serialport"
 repository = "https://github.com/serialport/serialport-rs"

--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ can help debug software or hardware errors.
 
 # Dependencies
 
-Rust versions 1.59.0 and higher are supported.
+Rust versions 1.59.0 and higher are supported by the library itself. There are
+examples requiring newer versions of Rust.
 
 For GNU/Linux `pkg-config` headers are required:
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![crates.io version badge](https://img.shields.io/crates/v/serialport.svg)](https://crates.io/crates/serialport)
 [![Documentation](https://docs.rs/serialport/badge.svg)](https://docs.rs/serialport)
 [![GitHub workflow status](https://img.shields.io/github/actions/workflow/status/serialport/serialport-rs/ci.yaml?branch=main&logo=github)](https://github.com/serialport/serialport-rs/actions)
-[![Minimum Stable Rust Version](https://img.shields.io/badge/Rust-1.56.1-blue?logo=rust)](https://blog.rust-lang.org/2021/11/01/Rust-1.56.1.html)
+[![Minimum Stable Rust Version](https://img.shields.io/badge/Rust-1.59.0-blue?logo=rust)](https://blog.rust-lang.org/2022/02/24/Rust-1.59.0.html)
 
 > **Note:** This is a fork of the original
 [serialport-rs](https://gitlab.com/susurrus/serialport-rs) project on GitLab. Please note there have
@@ -109,7 +109,7 @@ can help debug software or hardware errors.
 
 # Dependencies
 
-Rust versions 1.56.1 and higher are supported.
+Rust versions 1.59.0 and higher are supported.
 
 For GNU/Linux `pkg-config` headers are required:
 

--- a/src/posix/enumerate.rs
+++ b/src/posix/enumerate.rs
@@ -91,7 +91,7 @@ fn udev_property_encoded_or_replaced_as_string(
     replaced_key: &str,
 ) -> Option<String> {
     udev_property_as_string(d, encoded_key)
-        .and_then(|s| unescape::unescape(&s))
+        .and_then(|s| unescaper::unescape(&s).ok())
         .or_else(|| udev_property_as_string(d, replaced_key))
         .map(udev_restore_spaces)
 }


### PR DESCRIPTION
* This addresses #134 and likely #129
* Previously, our lookup preferred the information from udev's hardware database over the information provided by USB devices itself
    * The former is static an will for example provide the following for a SiliconLabs microcontroller eval board with a J-LINK interface
        ```
        $ cargo run --release --example list_ports
        [...]
          /dev/ttyACM0
            Type: USB
            VID:1366 PID:0105
             Serial Number: [...]
              Manufacturer: SEGGER
                   Product: Zeppelin USB 3.0 Host controller
        [...]
        ```
    * Which even looks like faulty product information as this board has an USB 2.0 interface and is definitely no host controller
    * With this PR, the information from the device will be provided
        ```
        $ cargo run --release --example list_ports
        [...]
          /dev/ttyACM0
            Type: USB
            VID:1366 PID:0105
             Serial Number: [...]
              Manufacturer: Silicon Labs
                   Product: J-Link OB
        [...]
        ```
* This change will break existing lookups due to different manufacturer and product information returned
    * We can state this in our changelog
    * Do we have the chance to prevent automatic updates by `cargo update` by releasing this change with a minor release?