### PR TITLE
update assert_hex crate to 0.4.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ scopeguard = "1.1"
 serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
-assert_hex = "0.2.2"
+assert_hex = "0.4.1"
 clap = { version = "3.1.6", features = ["derive"] }
 
 [features]


### PR DESCRIPTION
i checked the crate cargo toml and it seems that there are no conflict, they're still at rust 2018 version and the minimum required compiler is older than the minimum required by this library