### PR TITLE
Remove outdated RUSTSEC exemption for macOS

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -50,7 +50,6 @@ notice = "deny"
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
-    "RUSTSEC-2020-0168", # caused by unmaintained mach dependency of core-foundation-sys
     "RUSTSEC-2021-0145", # caused by unmaintained atty
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score


### PR DESCRIPTION
This got fixed with #136 but the exemption for the mach crate survived but is no longer needed. Keeping it in place would prevent us from getting notified from CI in case this dependency would be reintroduced by accident.