### PR TITLE
windows: Use correct serial number for composite devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@ project adheres to [Semantic Versioning](https://semver.org/).
   [#130](https://github.com/serialport/serialport-rs/pull/130)
 
 ### Fixed
-
+* Fixes a bug on Windows where composite devices would show a incorrect serial
+  number.
+  [#141](https://github.com/serialport/serialport-rs/pull/141)
 * Fixes a bug on Linux without udev where `available_ports()` returned wrong
   device file paths.
   [#122](https://github.com/serialport/serialport-rs/pull/122)


### PR DESCRIPTION
Fetch the serial number from the interface's parent device, as it contains the correct serial number on its HWID.

Prior to this commit:
![image](https://github.com/serialport/serialport-rs/assets/8076962/184cdf28-e088-4c62-ad08-4cbdb8ca53ef)

After this commit:
![image](https://github.com/serialport/serialport-rs/assets/8076962/dded92f4-e1c3-4539-a49a-5a149cff1bfa)

From USBDeview:
![image](https://github.com/serialport/serialport-rs/assets/8076962/2cd46b7e-99c3-43bb-ad34-329a5ec90182)

This is a follow-up of https://github.com/serialport/serialport-rs/pull/131