### PR TITLE
Clear input/output buffers on macOS upon TTY open

### DIFF
--- a/src/posix/tty.rs
+++ b/src/posix/tty.rs
@@ -156,6 +156,11 @@ impl TTYPort {
             ));
         };
 
+        #[cfg(any(target_os = "ios", target_os = "macos"))]
+        if builder.baud_rate > 0 {
+            unsafe { libc::tcflush(fd.0, libc::TCIOFLUSH) };
+        }
+
         // clear O_NONBLOCK flag
         fcntl(fd.0, F_SETFL(nix::fcntl::OFlag::empty()))?;
 


### PR DESCRIPTION
I don't understand why this works, but it resolves problematic behavior (#49) on macOS. Bisecting history, I found commit
3d6c1b25e3430e45290da752e01da96e81beddc3, which removed flushing the IO buffers for a TTY, was problematic on macOS. However, the test `test_osx_pty_pair` which tests pseudo-ttys with baud_rate 0 on macOS (introduced in b54264b2588879bdca4aeb69c5b91f8a4bf980cb) fails if I simply reintroduced flushing. Therefore, this change now re-introduces flushing the IO buffers upon opening a TTY, but only on macOS and only when baud-rate is non-zero.

Thanks to @berkus for the original work.

This supersedes #133.