### PR TITLE
Prepare release 4.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,16 @@ project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 ### Changed
 
+* Raise MSRV from 1.56.1 to 1.59.0 and Rust edition from 2018 to 2021.
+  [#137](https://github.com/serialport/serialport-rs/pull/137)
 * Update `bitflags` dependency to 2.4.0.
   [#127](https://github.com/serialport/serialport-rs/pull/127)
-- Open serial devices with `O_CLOEXEC` (Posix). This will close the device
+* Open serial devices with `O_CLOEXEC` (Posix). This will close the device
   handles when starting a child process. In particular this means that a serial
   device can be reopened after making SW update of a Tauri application.
   [#130](https://github.com/serialport/serialport-rs/pull/130)
 * Prefer USB device manufacturer and model information from the actual USB
   device over the information from udev's database.
-  [#137](https://github.com/serialport/serialport-rs/pull/137)
-* Raise MSRV from 1.56.1 to 1.59.0.
   [#137](https://github.com/serialport/serialport-rs/pull/137)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,8 +34,6 @@ project adheres to [Semantic Versioning](https://semver.org/).
   [#112](https://github.com/serialport/serialport-rs/issues/112),
   [#136](https://github.com/serialport/serialport-rs/pull/136)
 
-### Removed
-
 ## [4.2.2] - 2023-08-03
 ### Fixed
 * Fixes a bug on the Raspberry Pi 4, which results in USB-devices being detected as PCI-devices.
@@ -72,7 +70,6 @@ project adheres to [Semantic Versioning](https://semver.org/).
   [#68](https://github.com/serialport/serialport-rs/pull/68)
 * A number of memory leaks have been addressed when using serialport-rs.
   [#98](https://github.com/serialport/serialport-rs/pull/98)
-### Removed
 
 ## [4.2.0] - 2022-06-02
 ### Added
@@ -91,7 +88,6 @@ project adheres to [Semantic Versioning](https://semver.org/).
 ### Fixed
 * Set port timeout to a non-zero value before performing loopback test.
   [#45](https://github.com/serialport/serialport-rs/pull/45)
-### Removed
 
 ## [4.1.0] - 2022-04-04
 ### Added
@@ -110,17 +106,14 @@ project adheres to [Semantic Versioning](https://semver.org/).
 * Make sure fd is properly closed if initialization fails.
   [#39](https://github.com/serialport/serialport-rs/pull/39)
   [#41](https://github.com/serialport/serialport-rs/pull/41)
-### Removed
 
 ## [4.0.1] - 2021-04-17
-### Added
 ### Changed
 * Update maintenance status to looking for a new maintainer.
 ### Fixed
 * Properly initialize DCB structure on Windows. This fixes some non-functional
   devices.
   [!97](https://gitlab.com/susurrus/serialport-rs/-/merge_requests/97)
-### Removed
 
 ## [4.0.0] - 2020-12-17
 ### Added
@@ -179,8 +172,6 @@ project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 * Upgraded `sparc64-unknown-linux-gnu` to Tier 2 support.
-
-### Removed
 
 ## [3.2.0] - 2019-01-01
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 ### Added
 ### Changed
+### Fixed
+### Removed
+
+## [4.3.0] - 2023-12-11
+
+### Changed
 
 * Raise MSRV from 1.56.1 to 1.59.0 and Rust edition from 2018 to 2021.
   [#137](https://github.com/serialport/serialport-rs/pull/137)
@@ -370,7 +376,8 @@ Unreleased, happened due to a user error using `cargo-release`.
 * Initial release.
 
 
-[Unreleased]: https://github.com/serialport/serialport-rs/compare/v4.2.2...HEAD
+[Unreleased]: https://github.com/serialport/serialport-rs/compare/v4.3.0...HEAD
+[4.3.0]: https://github.com/serialport/serialport-rs/compare/v4.2.2...v4.3.0
 [4.2.2]: https://github.com/serialport/serialport-rs/compare/v4.2.1...v4.2.2
 [4.2.1]: https://github.com/serialport/serialport-rs/compare/v4.2.0...v4.2.1
 [4.2.0]: https://github.com/serialport/serialport-rs/compare/v4.1.0...v4.2.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serialport"
-version = "4.2.3-alpha.0"
+version = "4.3.0"
 authors = [
     "Bryant Mairs <bryant@mai.rs>",
     "Jesse Braham <jesse@beta7.io>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serialport"
-version = "4.3.0"
+version = "4.3.1-alpha.0"
 authors = [
     "Bryant Mairs <bryant@mai.rs>",
     "Jesse Braham <jesse@beta7.io>",

--- a/README.md
+++ b/README.md
@@ -3,18 +3,6 @@
 [![GitHub workflow status](https://img.shields.io/github/actions/workflow/status/serialport/serialport-rs/ci.yaml?branch=main&logo=github)](https://github.com/serialport/serialport-rs/actions)
 [![Minimum Stable Rust Version](https://img.shields.io/badge/Rust-1.59.0-blue?logo=rust)](https://blog.rust-lang.org/2022/02/24/Rust-1.59.0.html)
 
-> **Note:** This is a fork of the original
-[serialport-rs](https://gitlab.com/susurrus/serialport-rs) project on GitLab. Please note there have
-been some changes to both the supported targets and which tier some targets are in, and there may be
-further changes to this made. Additionally, all relevant issues have been migrated to this
-repository.
-
-Join the discussion on Matrix!
-[#serialport-rs:matrix.org](https://matrix.to/#/#serialport-rs:matrix.org)
-
-**This project is looking for maintainers! If you are interested please let us know on Matrix, or by
-[creating a discussion](https://github.com/serialport/serialport-rs/discussions/new).**
-
 # Introduction
 
 `serialport-rs` is a general-purpose cross-platform serial port library for Rust. It provides a
@@ -22,6 +10,13 @@ blocking I/O interface and port enumeration on POSIX and Windows systems.
 
 For async I/O functionality, see the [mio-serial](https://github.com/berkowski/mio-serial) and
 [tokio-serial](https://github.com/berkowski/tokio-serial) crates.
+
+Join the discussion on Matrix!
+[#serialport-rs:matrix.org](https://matrix.to/#/#serialport-rs:matrix.org)
+
+**This project is looking for maintainers! Especially for Windows. If you are interested please let
+us know on Matrix, or by [creating a
+discussion](https://github.com/serialport/serialport-rs/discussions/new).**
 
 # Overview
 
@@ -183,8 +178,8 @@ without any additional terms or conditions.
 
 # Acknowledgments
 
+This is the continuation of the development at <https://gitlab.com/susurrus/serialport-rs>. Thanks
+to susurrus and all other contributors to the original project on GitLab.
+
 Special thanks to dcuddeback, willem66745, and apoloval who wrote the original serial-rs library
 which this library heavily borrows from.
-
-Additional thanks to susurrus and all other contributors to the original
-[serialport-rs](https://gitlab.com/susurrus/serialport-rs) project on GitLab.

--- a/doc/index.md
+++ b/doc/index.md
@@ -10,9 +10,9 @@ Serial ports are some of the oldest external interfaces exposed by system kernel
 
 ## References
 
- * https://github.com/pyserial/pyserial/blob/master/serial/serialposix.py#L354
- * https://github.com/Fazecast/jSerialComm/blob/master/src/main/c/OSX/SerialPort_OSX.c#L241
- * https://github.com/node-serialport/node-serialport/blob/master/src/serialport_unix.cpp#L137
- * https://github.com/jacobsa/go-serial/blob/master/serial/open_darwin.go#L239
- * https://github.com/nyholku/purejavacomm/blob/master/src/jtermios/macosx/JTermiosImpl.java#L434
- * https://github.com/npat-efault/picocom/blob/master/termios2.txt
+ * <https://github.com/pyserial/pyserial/blob/master/serial/serialposix.py#L354>
+ * <https://github.com/Fazecast/jSerialComm/blob/v2.0.2/src/main/c/OSX/SerialPort_OSX.c#L241>
+ * <https://github.com/node-serialport/node-serialport/blob/a31078f054f23c47e9de7cc8b1c7e79d6e4e6c0c/src/serialport_unix.cpp#L137>
+ * <https://github.com/jacobsa/go-serial/blob/master/serial/open_darwin.go#L239>
+ * <https://github.com/nyholku/purejavacomm/blob/master/src/jtermios/macosx/JTermiosImpl.java#L434>
+ * <https://github.com/npat-efault/picocom/blob/master/termios2.txt>


### PR DESCRIPTION
There have been a lot of updates since 4.2.2. Enough to cut a new release. A minor one, since we've bumped MSRV and the Rust edition.

I took the freedom to clean up the README.md since we are sailing here since a wile.