### PR TITLE
windows: Exclude disabled ports from `available_ports()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 ### Changed
 ### Fixed
+* Fixes a bug where `available_ports()` returned disabled devices on Windows.
+  [#144](https://github.com/serialport/serialport-rs/pull/144)
+
 ### Removed
 
 ## [4.3.0] - 2023-12-11


### PR DESCRIPTION
Uses [`CM_Get_DevNode_Status`](https://learn.microsoft.com/en-us/windows/win32/api/cfgmgr32/nf-cfgmgr32-cm_get_devnode_status) function to query device status and exclude devices reporting problems, such as being disabled by the user in Device Manager.