### PR TITLE
Fix write timeout for COM ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ project adheres to [Semantic Versioning](https://semver.org/).
 ### Fixed
 * Fixes a bug where `available_ports()` returned disabled devices on Windows.
   [#144](https://github.com/serialport/serialport-rs/pull/144)
+* Fixes a bug on Windows where the `WriteTotalTimeoutConstant` field hasn't been
+  configured properly when the `set_timeout` method is called.
+  [#124](https://github.com/serialport/serialport-rs/issues/124)
 
 ### Removed
 

--- a/src/windows/com.rs
+++ b/src/windows/com.rs
@@ -240,14 +240,14 @@ impl SerialPort for COMPort {
     }
 
     fn set_timeout(&mut self, timeout: Duration) -> Result<()> {
-        let milliseconds = timeout.as_secs() * 1000 + timeout.subsec_nanos() as u64 / 1_000_000;
+        let milliseconds = timeout.as_millis();
 
         let mut timeouts = COMMTIMEOUTS {
             ReadIntervalTimeout: 0,
             ReadTotalTimeoutMultiplier: 0,
             ReadTotalTimeoutConstant: milliseconds as DWORD,
             WriteTotalTimeoutMultiplier: 0,
-            WriteTotalTimeoutConstant: 0,
+            WriteTotalTimeoutConstant: milliseconds as DWORD,
         };
 
         if unsafe { SetCommTimeouts(self.handle, &mut timeouts) } == 0 {


### PR DESCRIPTION
Resolves the issue where the COM-port write procedure is blocking, which is caused by a static timeout deceleration equal to zero. In general, you would suspect that the `set_timeout` builder method applies a timeout to both the read and write procedures, as the documentation would suggest.

Fixes #124 