### PR TITLE
Fix enumeration of USB devices without a short serial on Raspberry Pi 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 ### Changed
 ### Fixed
+
+* Fix enumeration USB reported as PCI devices which do not have a (short)
+  serial number.
+  [#160](https://github.com/serialport/serialport-rs/pull/160)
+
 ### Removed
 
 

--- a/src/posix/enumerate.rs
+++ b/src/posix/enumerate.rs
@@ -142,7 +142,6 @@ fn port_type(d: &libudev::Device) -> Result<SerialPortType> {
                 d.property_value("ID_USB_MODEL_ID"),
                 d.property_value("ID_USB_VENDOR"),
                 d.property_value("ID_USB_MODEL"),
-                d.property_value("ID_USB_SERIAL_SHORT"),
             ]
             .into_iter()
             .collect::<Option<Vec<_>>>();

--- a/src/posix/enumerate.rs
+++ b/src/posix/enumerate.rs
@@ -140,8 +140,6 @@ fn port_type(d: &libudev::Device) -> Result<SerialPortType> {
             let usb_properties = vec![
                 d.property_value("ID_USB_VENDOR_ID"),
                 d.property_value("ID_USB_MODEL_ID"),
-                d.property_value("ID_USB_VENDOR"),
-                d.property_value("ID_USB_MODEL"),
             ]
             .into_iter()
             .collect::<Option<Vec<_>>>();


### PR DESCRIPTION
This will fix the issue with USB devices that do not have a short serial and are not listed when using `serialport::available_ports()`. `serial_number` is an optional field in the `UsbPortInfo` struct and is not required to be available.

In my specifc case I have the USB device "USB-Serial_Controller" from "Prolific_Technology_Inc." (vid:  0x067b, pid: 0x2303). When connected to a Raspberry 4 it is not shown. This pull request fixes this.

Related to #113 