### PR TITLE
feat: FlowControl: add FromStr impl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 ### Added
 * Added conversions between `DataBits`, `StopBits` types and their numeric representations
+* Added `FromStr` implementation for `FlowControl`
 ### Changed
 ### Fixed
 * Fixes a bug where `available_ports()` returned disabled devices on Windows.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@ use std::convert::From;
 use std::error::Error as StdError;
 use std::fmt;
 use std::io;
+use std::str::FromStr;
 use std::time::Duration;
 
 #[cfg(unix)]
@@ -280,6 +281,19 @@ impl fmt::Display for FlowControl {
             FlowControl::None => write!(f, "None"),
             FlowControl::Software => write!(f, "Software"),
             FlowControl::Hardware => write!(f, "Hardware"),
+        }
+    }
+}
+
+impl FromStr for FlowControl {
+    type Err = ();
+
+    fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
+        match s {
+            "None" | "none" | "n" => Ok(FlowControl::None),
+            "Software" | "software" | "SW" | "sw" | "s" => Ok(FlowControl::Software),
+            "Hardware" | "hardware" | "HW" | "hw" | "h" => Ok(FlowControl::Hardware),
+            _ => Err(()),
         }
     }
 }


### PR DESCRIPTION
Allow creating a 'FlowControl' enum from a 'str' type. This is useful when parsing strings from config files or command line arguments.