### PR TITLE
Use regex-lite instead of Regex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ io-kit-sys = "0.4.0"
 mach2 = "0.4.1"
 
 [target."cfg(windows)".dependencies]
-regex = "1.5.5"
+regex-lite = "0.1"
 
 [target."cfg(windows)".dependencies.winapi]
 version = "0.3.9"

--- a/src/windows/enumerate.rs
+++ b/src/windows/enumerate.rs
@@ -1,7 +1,7 @@
 use std::ffi::{CStr, CString};
 use std::{mem, ptr};
 
-use regex::Regex;
+use regex_lite::Regex;
 use winapi::shared::guiddef::*;
 use winapi::shared::minwindef::*;
 use winapi::shared::winerror::*;


### PR DESCRIPTION
Switches to using regex-lite rather than Regex. This improve comile time significantly as Regex is pretty chonky, and the regex is not used in a performance critical (imo) area. 

My computer is a Windows 10 laptop with an i7-12800H. With rustc 1.77.0, compiling the tests & the rlib.

## Release Builds
### Regex
```powershell
> rmdir -r -Force target
> Measure-Command { cargo test --no-run -r }
...
Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 42
Milliseconds      : 792
Ticks             : 427928612
TotalDays         : 0.00049528774537037
TotalHours        : 0.0118869058888889
TotalMinutes      : 0.713214353333333
TotalSeconds      : 42.7928612
TotalMilliseconds : 42792.8612

> rmdir -r -Force target
> Measure-Command { cargo build -r }
...
Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 12
Milliseconds      : 96
Ticks             : 120962426
TotalDays         : 0.00014000280787037
TotalHours        : 0.00336006738888889
TotalMinutes      : 0.201604043333333
TotalSeconds      : 12.0962426
TotalMilliseconds : 12096.2426
```

### Regex-Lite
```powershell
> rmdir -r -Force target
> Measure-Command { cargo test --no-run -r }
...
Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 30
Milliseconds      : 539
Ticks             : 305397015
TotalDays         : 0.000353468767361111
TotalHours        : 0.00848325041666667
TotalMinutes      : 0.508995025
TotalSeconds      : 30.5397015
TotalMilliseconds : 30539.7015

> rmdir -r -Force target
> Measure-Command { cargo build -r }
...
Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 4
Milliseconds      : 665
Ticks             : 46651654
TotalDays         : 5.39949699074074E-05
TotalHours        : 0.00129587927777778
TotalMinutes      : 0.0777527566666667
TotalSeconds      : 4.6651654
TotalMilliseconds : 4665.1654
```

## Debug Builds

### Regex
```powershell
> rmdir -r -Force target
> Measure-Command { cargo test --no-run }
...
Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 10
Milliseconds      : 84
Ticks             : 100848322
TotalDays         : 0.000116722594907407
TotalHours        : 0.00280134227777778
TotalMinutes      : 0.168080536666667
TotalSeconds      : 10.0848322
TotalMilliseconds : 10084.8322
> rmdir -r -Force target
> Measure-Command { cargo build }
...
Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 4
Milliseconds      : 683
Ticks             : 46834151
TotalDays         : 5.4206193287037E-05
TotalHours        : 0.00130094863888889
TotalMinutes      : 0.0780569183333333
TotalSeconds      : 4.6834151
TotalMilliseconds : 4683.4151
```
### Regex-Lite
```powershell
> rmdir -r -Force target
> Measure-Command { cargo test --no-run }
...
Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 10
Milliseconds      : 251
Ticks             : 102519623
TotalDays         : 0.000118656971064815
TotalHours        : 0.00284776730555556
TotalMinutes      : 0.170866038333333
TotalSeconds      : 10.2519623
TotalMilliseconds : 10251.9623
> rmdir -r -Force target
> Measure-Command { cargo build }
...
Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 3
Milliseconds      : 773
Ticks             : 37735125
TotalDays         : 4.36749131944444E-05
TotalHours        : 0.00104819791666667
TotalMinutes      : 0.062891875
TotalSeconds      : 3.7735125
TotalMilliseconds : 3773.5125
```

So it is much more important in release builds. But there are modest improvements in debug builds too. But I've worked hard to bring compilation times down in my app, and compiling Regex for this crate is currently the longest single crate in terms of wall-time. 