### PR TITLE
Fix nightly

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,6 +46,8 @@ env:
   CARGO_TERM_COLOR: always
   # Enable cross compilation for `pkg_config`.
   PKG_CONFIG_ALLOW_CROSS: 1
+  # Deny warnings.
+  RUSTFLAGS: -D warnings
 
 jobs:
   build:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,6 +18,9 @@ on:
       toolchain:
         default: stable
         type: string
+      continue-on-error:
+        default: false
+        type: boolean
 
 env:
   # While we could define these on a per-job basis, there's no harm in simply
@@ -52,6 +55,7 @@ env:
 jobs:
   build:
     runs-on: ${{ inputs.runs_on }}
+    continue-on-error: ${{ inputs.continue-on-error }}
     steps:
       - name: Build | install dependencies
         if: inputs.runs_on == 'ubuntu-latest'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -245,9 +245,22 @@ jobs:
       disable_tests: true
       target: x86_64-unknown-netbsd
 
+  # --------------------------------------------------------------------------
+  # NIGHTLY BUILD
+
+  aarch64-apple-darwin-nightly:
+    uses: ./.github/workflows/build.yaml
+    with:
+      continue-on-error: true
+      disable_tests: true
+      runs_on: macos-latest
+      target: aarch64-apple-darwin
+      toolchain: nightly
+
   x86_64-pc-windows-msvc-nightly:
     uses: ./.github/workflows/build.yaml
     with:
+      continue-on-error: true
       runs_on: windows-2019
       target: x86_64-pc-windows-msvc
       toolchain: nightly
@@ -255,14 +268,7 @@ jobs:
   x86_64-unknown-linux-gnu-nightly:
     uses: ./.github/workflows/build.yaml
     with:
+      continue-on-error: true
       extra_packages: libudev-dev
       target: x86_64-unknown-linux-gnu
-      toolchain: nightly
-
-  aarch64-apple-darwin-nightly:
-    uses: ./.github/workflows/build.yaml
-    with:
-      disable_tests: true
-      runs_on: macos-latest
-      target: aarch64-apple-darwin
       toolchain: nightly

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -244,3 +244,25 @@ jobs:
       disable_extra_builds: true
       disable_tests: true
       target: x86_64-unknown-netbsd
+
+  x86_64-pc-windows-msvc-nightly:
+    uses: ./.github/workflows/build.yaml
+    with:
+      runs_on: windows-2019
+      target: x86_64-pc-windows-msvc
+      toolchain: nightly
+
+  x86_64-unknown-linux-gnu-nightly:
+    uses: ./.github/workflows/build.yaml
+    with:
+      extra_packages: libudev-dev
+      target: x86_64-unknown-linux-gnu
+      toolchain: nightly
+
+  aarch64-apple-darwin-nightly:
+    uses: ./.github/workflows/build.yaml
+    with:
+      disable_tests: true
+      runs_on: macos-latest
+      target: aarch64-apple-darwin
+      toolchain: nightly

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,8 +19,7 @@
 #![deny(
     missing_docs,
     missing_debug_implementations,
-    missing_copy_implementations,
-    unused
+    missing_copy_implementations
 )]
 // Document feature-gated elements on docs.rs. See
 // https://doc.rust-lang.org/rustdoc/unstable-features.html?highlight=doc(cfg#doccfg-recording-what-platforms-or-features-are-required-for-code-to-be-present

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,6 @@
 // doc tests.
 #![doc(test(attr(allow(unused_must_use))))]
 
-use std::convert::From;
 use std::error::Error as StdError;
 use std::fmt;
 use std::io;

--- a/src/posix/tty.rs
+++ b/src/posix/tty.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use std::{io, mem};
 
 use nix::fcntl::{fcntl, OFlag};
-use nix::{self, libc, unistd};
+use nix::{libc, unistd};
 
 use crate::posix::ioctl::{self, SerialLines};
 use crate::posix::termios;


### PR DESCRIPTION
Currently this crate does not build on nightly due to lint changes. Specially there are two lines that cause compilation failure:

A `deny(unused)` lint:
https://github.com/serialport/serialport-rs/blob/84f6066ffd92056829b91771afc7eebcbc6642e2/src/lib.rs#L23

And importing a trait included in the prelude:
https://github.com/serialport/serialport-rs/blob/84f6066ffd92056829b91771afc7eebcbc6642e2/src/lib.rs#L35

If you attempt to build on nightly you get this error:
```log
error: the item `From` is imported redundantly
   --> src\lib.rs:35:5
    |
35  | use std::convert::From;
    |     ^^^^^^^^^^^^^^^^^^
    |
   ::: C:\Users\rsmyth\.rustup\toolchains\nightly-x86_64-pc-windows-msvc\lib/rustlib/src/rust\library\std\src\prelude\mod.rs:129:13
    |
129 |     pub use core::prelude::rust_2021::*;
    |             ------------------------ the item `From` is already defined here
    |
note: the lint level is defined here
   --> src\lib.rs:23:5
    |
23  |     unused
    |     ^^^^^^
    = note: `#[deny(unused_imports)]` implied by `#[deny(unused)]`

error: could not compile `serialport` (lib) due to 1 previous error
```

This fixes the lint, and add nightly to CI. I'm not that great at GitHub actions wrangling so it may be incorrectly formed. We'll see.
rust-lang/rust#121315