### PR TITLE
Try find port type in parent device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ project adheres to [Semantic Versioning](https://semver.org/).
 
 * Add `IntoRawHandle` implementation for `COMPort`
   [#199](https://github.com/serialport/serialport-rs/pull/199)
+* Add MODALIAS as additional source of information for USB devices on Linux
+  [#170](https://github.com/serialport/serialport-rs/pull/170)
 
 ### Changed
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ nix = { version = "0.26", default-features = false, features = ["fs", "ioctl", "
 [target.'cfg(all(target_os = "linux", not(target_env = "musl")))'.dependencies]
 libudev = { version = "0.3.0", optional = true }
 unescaper = "0.1.3"
-regex = "1.5.5"
 
 [target.'cfg(any(target_os = "ios", target_os = "macos"))'.dependencies]
 core-foundation-sys = "0.8.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ nix = { version = "0.26", default-features = false, features = ["fs", "ioctl", "
 [target.'cfg(all(target_os = "linux", not(target_env = "musl")))'.dependencies]
 libudev = { version = "0.3.0", optional = true }
 unescaper = "0.1.3"
+regex = "1.5.5"
 
 [target.'cfg(any(target_os = "ios", target_os = "macos"))'.dependencies]
 core-foundation-sys = "0.8.4"


### PR DESCRIPTION
for docker enviroment  udev not run well for device add by --device 
without ID_BUS like ID* property, but we still can try find the must info from its parent.

below is sample output from udevadm info -t /dev/ttyACM0

> └─1-4:1.0
>           ┆ P: /devices/pci0000:00/0000:00:02.1/0000:01:00.0/usb1/1-4/1-4:1.0
>           ┆ E: DEVPATH=/devices/pci0000:00/0000:00:02.1/0000:01:00.0/usb1/1-4/1-4:1.0
>           ┆ E: SUBSYSTEM=usb
>           ┆ E: DEVTYPE=usb_interface
>           ┆ E: DRIVER=cdc_acm
>           ┆ E: PRODUCT=303a/1001/101
>           ┆ E: TYPE=239/2/1
>           ┆ E: INTERFACE=2/2/0
>           ┆ E: MODALIAS=usb:v303Ap1001d0101dcEFdsc02dp01ic02isc02ip00in00
>           └─tty/ttyACM0
>             ┆ P: /devices/pci0000:00/0000:00:02.1/0000:01:00.0/usb1/1-4/1-4:1.0/tty/ttyACM0
>             ┆ M: ttyACM0
>             ┆ R: 0
>             ┆ U: tty
>             ┆ D: c 166:0
>             ┆ N: ttyACM0
>             ┆ L: 0
>             ┆ E: DEVPATH=/devices/pci0000:00/0000:00:02.1/0000:01:00.0/usb1/1-4/1-4:1.0/tty/ttyACM0
>             ┆ E: SUBSYSTEM=tty
>             ┆ E: DEVNAME=/dev/ttyACM0
>             ┆ E: MAJOR=166
>             ┆ E: MINOR=0
> 