### PR TITLE
Fix some issues pointed out by Clippy in examples and tests

### DIFF
--- a/examples/clear_input_buffer.rs
+++ b/examples/clear_input_buffer.rs
@@ -125,7 +125,7 @@ fn input_service() -> mpsc::Receiver<()> {
                     drop(tx); // EOF, drop the channel and stop the thread
                     break;
                 }
-                Ok(_) => tx.send(()).unwrap(), // Signal main to clear the buffer
+                Ok(_bytes_read) => tx.send(()).unwrap(), // Signal main to clear the buffer
                 Err(e) => panic_any(e),
             }
         }

--- a/examples/clear_output_buffer.rs
+++ b/examples/clear_output_buffer.rs
@@ -85,7 +85,7 @@ fn run(port_name: &str, baud_rate: &str, block_size: usize) -> Result<(), Box<dy
     // This loop writes the block repeatedly, as fast as possible, to try to saturate the
     // output buffer. If you don't see much data queued to send, try changing the block size.
     loop {
-        match port.write(&block) {
+        match port.write_all(&block) {
             Ok(_) => (),
             Err(ref e) if e.kind() == io::ErrorKind::TimedOut => (),
             Err(e) => panic!("Error while writing data to the port: {}", e),
@@ -125,7 +125,7 @@ fn input_service() -> mpsc::Receiver<()> {
                     drop(tx); // EOF, drop the channel and stop the thread
                     break;
                 }
-                Ok(_) => tx.send(()).unwrap(), // Signal main to clear the buffer
+                Ok(_bytes_read) => tx.send(()).unwrap(), // Signal main to clear the buffer
                 Err(e) => panic_any(e),
             }
         }

--- a/tests/test_tty.rs
+++ b/tests/test_tty.rs
@@ -98,7 +98,7 @@ fn test_osx_pty_pair() {
     let (output_sink, output_stream) = std::sync::mpsc::sync_channel(1);
     let name = slave.name().unwrap();
 
-    master.write("12".as_bytes()).expect("");
+    master.write_all("12".as_bytes()).expect("");
 
     let reader_thread = std::thread::spawn(move || {
         let mut port = TTYPort::open(&serialport::new(&name, 0)).expect("unable to open");


### PR DESCRIPTION
They surfaced in the CI builds for #168 and look like new catches from the latest Clippy as it is already present in main (https://github.com/serialport/serialport-rs/actions/runs/8470256382). The intentions in the examples an the test code look clears up the ambiguous parts in the code.