### PR TITLE
Implement configurable buffer size on Windows (#173)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -489,6 +489,9 @@ pub trait SerialPort: Send + io::Read + io::Write {
     /// Sets the timeout for future I/O operations.
     fn set_timeout(&mut self, timeout: Duration) -> Result<()>;
 
+    /// Set the buffer size
+    fn set_buffer_size(&mut self, receive_size: usize, transmit_size: usize) -> Result<()>;
+
     // Functions for setting non-data control signal pins
 
     /// Sets the state of the RTS (Request To Send) control signal.
@@ -675,6 +678,10 @@ impl<T: SerialPort> SerialPort for &mut T {
 
     fn set_timeout(&mut self, timeout: Duration) -> Result<()> {
         (**self).set_timeout(timeout)
+    }
+
+    fn set_buffer_size(&mut self, receive_size: usize, transmit_size: usize) -> Result<()> {
+        (**self).set_buffer_size(receive_size, transmit_size)
     }
 
     fn write_request_to_send(&mut self, level: bool) -> Result<()> {

--- a/src/posix/tty.rs
+++ b/src/posix/tty.rs
@@ -675,6 +675,13 @@ impl SerialPort for TTYPort {
         Ok(())
     }
 
+    fn set_buffer_size(&self, _rx: u32, _tx: u32) -> Result<()> {
+        Err(Error::new(
+            ErrorKind::Unsupported,
+            "Configurable buffer sizes are not supported on this platform",
+        ))
+    }
+
     fn write_request_to_send(&mut self, level: bool) -> Result<()> {
         self.set_pin(SerialLines::REQUEST_TO_SEND, level)
     }

--- a/src/windows/com.rs
+++ b/src/windows/com.rs
@@ -258,6 +258,13 @@ impl SerialPort for COMPort {
         Ok(())
     }
 
+    fn set_buffer_size(&mut self, receive_size: usize, transmit_size: usize) -> Result<()> {
+        match unsafe { SetupComm(self.handle, receive_size as DWORD, transmit_size as DWORD) } {
+            0 => Err(super::error::last_os_error()),
+            _ => Ok(()),
+        }
+    }
+
     fn write_request_to_send(&mut self, level: bool) -> Result<()> {
         if level {
             self.escape_comm_function(SETRTS)

--- a/tests/test_buffer_size.rs
+++ b/tests/test_buffer_size.rs
@@ -1,0 +1,35 @@
+#![cfg(windows)]
+extern crate serialport;
+
+#[test]
+fn test_set_large_buffer() {
+    const STRIDE: usize = 2;
+    const WORDS : usize = 65536;
+    const BYTES: usize = WORDS * STRIDE;
+
+    let mut tx_port = serialport::new("COM12", 9600).open().unwrap();
+    let mut rx_port = serialport::new("COM13", 9600).open().unwrap();
+
+    tx_port.set_buffer_size(0, BYTES).unwrap();
+    rx_port.set_buffer_size(BYTES, 0).unwrap();
+
+    let mut rx_buf = [0_u8; BYTES];
+    let mut tx_buf = [0_u8; BYTES];
+
+    for i in 0..WORDS {
+        for j in 0..STRIDE {
+            tx_buf[i * STRIDE + j] = (i >> (j * 8) & 0xFF) as u8;
+        }
+    }
+
+    tx_port.write_all(&tx_buf[..]).unwrap();
+    rx_port.read_exact(&mut rx_buf).unwrap();
+
+    let transmitted = tx_buf.to_vec();
+    let received = rx_buf.to_vec();
+
+    println!("Transmitted: {:?}", &transmitted[..8]);
+    println!("Received: {:?}", &received[..8]);
+
+    assert_eq!(transmitted, received);
+}


### PR DESCRIPTION
I've added the implementation to configure the buffer size on Windows.
I don't know Linux well enough to add a proper implementation, so for now I've made it always return an error with the Unsupported error kind - I don't know if it's even possible to configure the buffer size on Linux.