### PR TITLE
Clean up integration tests

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[env]
+# Some of our tests make use of actual serial ports. Run all tests sequentially
+# by default to avoid race conditions (see
+# https://github.com/rust-lang/cargo/issues/8430).
+RUST_TEST_THREADS = "1"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -51,6 +51,10 @@ env:
   PKG_CONFIG_ALLOW_CROSS: 1
   # Deny warnings.
   RUSTFLAGS: -D warnings
+  # Dummy ports for hardware tests. Keep in sync with other workflows (in
+  # ci.yaml).
+  SERIALPORT_RS_TEST_PORT_1: DUMMY_PORT_1
+  SERIALPORT_RS_TEST_PORT_2: DUMMY_PORT_2
 
 jobs:
   build:
@@ -110,7 +114,7 @@ jobs:
 
       - name: Build | run tests (default features)
         if: ${{ inputs.disable_tests == false }}
-        run: cargo test --no-fail-fast --target=${{ inputs.target }}
+        run: cargo test --no-fail-fast --features ignore-hardware-tests --target=${{ inputs.target }}
 
       - name: Build | build tests (all features)
         if: ${{ inputs.disable_extra_builds == false }}
@@ -118,4 +122,5 @@ jobs:
 
       - name: Build | run tests (all features)
         if: ${{ inputs.disable_tests == false }}
+        # Enabling all features includes ignoring hardware tests.
         run: cargo test --no-fail-fast --all-features --target=${{ inputs.target }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,11 @@ on:
   push:
   workflow_dispatch:
 
+env:
+  # Dummy ports for hardware tests. Keep in sync with workflows in build.yaml.
+  SERIALPORT_RS_TEST_PORT_1: DUMMY_PORT_1
+  SERIALPORT_RS_TEST_PORT_2: DUMMY_PORT_2
+
 jobs:
   # --------------------------------------------------------------------------
   # LINT

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target
 Cargo.lock
 *.bk
 *~
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 target
 Cargo.lock
 *.bk
-.cargo
 *~

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ clap = { version = "3.1.6", features = ["derive"] }
 
 [features]
 default = ["libudev"]
+ignore-hardware-tests = []
 # TODO: Make the feature unconditionally available with the next major release
 # (5.0) and remove this feature gate.
 usbportinfo-interface = []

--- a/README.md
+++ b/README.md
@@ -122,10 +122,11 @@ feature):
 
 # Platform Support
 
-Builds and tests for all supported targets are run in CI. Failures of either block the inclusion of
-new code. This library should be compatible with additional targets not listed below, but no
-guarantees are made. Additional platforms may be added in the future if there is a need and/or
-demand.
+Builds and some tests (not requiring actual hardware) for all supported targets
+are run in CI. Failures of either block the inclusion of new code. This library
+should be compatible with additional targets not listed below, but no
+guarantees are made. Additional platforms may be added in the future if there
+is a need and/or demand.
 
 - Android
   - `arm-linux-androideabi` (no serial enumeration)

--- a/README.md
+++ b/README.md
@@ -122,11 +122,11 @@ feature):
 
 # Platform Support
 
-Builds and some tests (not requiring actual hardware) for all supported targets
-are run in CI. Failures of either block the inclusion of new code. This library
-should be compatible with additional targets not listed below, but no
-guarantees are made. Additional platforms may be added in the future if there
-is a need and/or demand.
+Builds and some tests (not requiring actual hardware) for major targets are run
+in CI. Failures of either block the inclusion of new code. This library should
+be compatible with additional targets not listed below, but no guarantees are
+made. Additional platforms may be added in the future if there is a need and/or
+demand.
 
 - Android
   - `arm-linux-androideabi` (no serial enumeration)

--- a/src/posix/termios.rs
+++ b/src/posix/termios.rs
@@ -8,7 +8,7 @@ use std::os::unix::prelude::*;
 
 cfg_if! {
     if #[cfg(any(
-        target_os = "dragonflybsd",
+        target_os = "dragonfly",
         target_os = "freebsd",
         target_os = "ios",
         target_os = "macos",
@@ -59,7 +59,7 @@ pub(crate) fn get_termios(fd: RawFd) -> Result<Termios> {
 }
 
 #[cfg(any(
-    target_os = "dragonflybsd",
+    target_os = "dragonfly",
     target_os = "freebsd",
     target_os = "netbsd",
     target_os = "openbsd",
@@ -111,7 +111,7 @@ pub(crate) fn set_termios(fd: RawFd, termios: &libc::termios, baud_rate: u32) ->
 }
 
 #[cfg(any(
-    target_os = "dragonflybsd",
+    target_os = "dragonfly",
     target_os = "freebsd",
     target_os = "netbsd",
     target_os = "openbsd",
@@ -222,7 +222,7 @@ pub(crate) fn set_baud_rate(termios: &mut Termios, baud_rate: u32) {
 
 // BSDs use the baud rate as the constant value so there's no translation necessary
 #[cfg(any(
-    target_os = "dragonflybsd",
+    target_os = "dragonfly",
     target_os = "freebsd",
     target_os = "netbsd",
     target_os = "openbsd"

--- a/src/posix/tty.rs
+++ b/src/posix/tty.rs
@@ -479,7 +479,7 @@ impl SerialPort for TTYPort {
     /// On some platforms this will be the actual device baud rate, which may differ from the
     /// desired baud rate.
     #[cfg(any(
-        target_os = "dragonflybsd",
+        target_os = "dragonfly",
         target_os = "freebsd",
         target_os = "netbsd",
         target_os = "openbsd"
@@ -622,7 +622,7 @@ impl SerialPort for TTYPort {
 
     #[cfg(any(
         target_os = "android",
-        target_os = "dragonflybsd",
+        target_os = "dragonfly",
         target_os = "freebsd",
         target_os = "netbsd",
         target_os = "openbsd",

--- a/src/posix/tty.rs
+++ b/src/posix/tty.rs
@@ -46,11 +46,16 @@ fn close(fd: RawFd) {
 /// ```
 /// use serialport::{TTYPort, SerialPort};
 ///
-/// let (mut master, slave) = TTYPort::pair().expect("Unable to create ptty pair");
+/// let (mut master, mut slave) = TTYPort::pair().expect("Unable to create ptty pair");
+///
+/// # let _ = &mut master;
+/// # let _ = &mut slave;
 ///
 /// // ... elsewhere
 ///
 /// let mut port = TTYPort::open(&serialport::new(slave.name().unwrap(), 0)).expect("unable to open");
+///
+/// # let _ = &mut port;
 /// ```
 #[derive(Debug)]
 pub struct TTYPort {
@@ -247,7 +252,10 @@ impl TTYPort {
     /// ```
     /// use serialport::TTYPort;
     ///
-    /// let (master, slave) = TTYPort::pair().unwrap();
+    /// let (mut master, mut slave) = TTYPort::pair().unwrap();
+    ///
+    /// # let _ = &mut master;
+    /// # let _ = &mut slave;
     /// ```
     pub fn pair() -> Result<(Self, Self)> {
         // Open the next free pty.

--- a/tests/test_serialport.rs
+++ b/tests/test_serialport.rs
@@ -4,6 +4,9 @@
 use serialport::*;
 use std::time::Duration;
 
+const PORT_1: &str = env!("SERIALPORT_RS_TEST_PORT_1");
+const PORT_2: &str = env!("SERIALPORT_RS_TEST_PORT_2");
+
 #[test]
 fn test_listing_ports() {
     let ports = serialport::available_ports().expect("No ports found!");
@@ -14,44 +17,46 @@ fn test_listing_ports() {
 
 #[test]
 fn test_opening_found_ports() {
+    // There is no guarantee that we even might open the ports returned by `available_ports`. But
+    // the ports we are using for testing shall be among them.
     let ports = serialport::available_ports().unwrap();
-    for p in ports {
-        let _port = serialport::new(p.port_name, 9600).open();
-    }
+    assert!(ports.iter().any(|info| info.port_name == PORT_1));
+    assert!(ports.iter().any(|info| info.port_name == PORT_2));
 }
 
 #[test]
 fn test_opening_port() {
-    let _port = serialport::new("/dev/ttyUSB0", 9600).open();
+    serialport::new(PORT_1, 9600).open().unwrap();
 }
 
 #[test]
 fn test_opening_native_port() {
-    let _port = serialport::new("/dev/ttyUSB0", 9600).open_native();
+    serialport::new(PORT_1, 9600).open_native().unwrap();
 }
 
 #[test]
 fn test_configuring_ports() {
-    let _port = serialport::new("/dev/ttyUSB0", 9600)
+    serialport::new(PORT_1, 9600)
         .data_bits(DataBits::Five)
         .flow_control(FlowControl::None)
         .parity(Parity::None)
         .stop_bits(StopBits::One)
         .timeout(Duration::from_millis(1))
-        .open();
+        .open()
+        .unwrap();
 }
 
 #[test]
 fn test_duplicating_port_config() {
-    let port1_config = serialport::new("/dev/ttyUSB0", 9600)
+    let port1_config = serialport::new(PORT_1, 9600)
         .data_bits(DataBits::Five)
         .flow_control(FlowControl::None)
         .parity(Parity::None)
         .stop_bits(StopBits::One)
         .timeout(Duration::from_millis(1));
 
-    let port2_config = port1_config.clone().path("/dev/ttyUSB1").baud_rate(115_200);
+    let port2_config = port1_config.clone().path(PORT_2).baud_rate(115_200);
 
-    let _port1 = port1_config.open();
-    let _port1 = port2_config.open();
+    let _port1 = port1_config.open().unwrap();
+    let _port1 = port2_config.open().unwrap();
 }

--- a/tests/test_serialport.rs
+++ b/tests/test_serialport.rs
@@ -8,6 +8,7 @@ const PORT_1: &str = env!("SERIALPORT_RS_TEST_PORT_1");
 const PORT_2: &str = env!("SERIALPORT_RS_TEST_PORT_2");
 
 #[test]
+#[cfg_attr(feature = "ignore-hardware-tests", ignore)]
 fn test_listing_ports() {
     let ports = serialport::available_ports().expect("No ports found!");
     for p in ports {
@@ -16,6 +17,7 @@ fn test_listing_ports() {
 }
 
 #[test]
+#[cfg_attr(feature = "ignore-hardware-tests", ignore)]
 fn test_opening_found_ports() {
     // There is no guarantee that we even might open the ports returned by `available_ports`. But
     // the ports we are using for testing shall be among them.
@@ -25,16 +27,19 @@ fn test_opening_found_ports() {
 }
 
 #[test]
+#[cfg_attr(feature = "ignore-hardware-tests", ignore)]
 fn test_opening_port() {
     serialport::new(PORT_1, 9600).open().unwrap();
 }
 
 #[test]
+#[cfg_attr(feature = "ignore-hardware-tests", ignore)]
 fn test_opening_native_port() {
     serialport::new(PORT_1, 9600).open_native().unwrap();
 }
 
 #[test]
+#[cfg_attr(feature = "ignore-hardware-tests", ignore)]
 fn test_configuring_ports() {
     serialport::new(PORT_1, 9600)
         .data_bits(DataBits::Five)
@@ -47,6 +52,7 @@ fn test_configuring_ports() {
 }
 
 #[test]
+#[cfg_attr(feature = "ignore-hardware-tests", ignore)]
 fn test_duplicating_port_config() {
     let port1_config = serialport::new(PORT_1, 9600)
         .data_bits(DataBits::Five)


### PR DESCRIPTION
This PRs cleans up some warnings from the doctests and makes tests using serial interfaces putting their cards on the table: The results of the operations under tests were just ignored beforehand and will be checked now.

Having the results checked now, requires the tests to use serial devices designated for testing. To keep a low profile, this is done by passing the devices via environment variables and rests requiring actual serial hardware can be ignored by default with the feature _ignore-hardware-tests_ which is done in CI.