### PR TITLE
Correct and update comment on TTYPort

### DIFF
--- a/src/posix/tty.rs
+++ b/src/posix/tty.rs
@@ -33,10 +33,13 @@ fn close(fd: RawFd) {
 
 /// A serial port implementation for POSIX TTY ports
 ///
-/// The port will be closed when the value is dropped. However, this struct
-/// should not be instantiated directly by using `TTYPort::open()`, instead use
-/// the cross-platform `serialport::open()` or
-/// `serialport::open_with_settings()`.
+/// The port will be closed when the value is dropped. This struct
+/// should not be instantiated directly by using `TTYPort::open()`.
+/// Instead, use the cross-platform `serialport::new()`. Example:
+///
+/// ```
+/// let mut port = serialport::new("/dev/ttyS0", 115200).open().expect("Unable to open");
+/// ```
 ///
 /// Note: on macOS, when connecting to a pseudo-terminal (`pty` opened via
 /// `posix_openpt`), the `baud_rate` should be set to 0; this will be used to
@@ -53,7 +56,7 @@ fn close(fd: RawFd) {
 ///
 /// // ... elsewhere
 ///
-/// let mut port = TTYPort::open(&serialport::new(slave.name().unwrap(), 0)).expect("unable to open");
+/// let mut port = TTYPort::open(&serialport::new(slave.name().unwrap(), 0)).expect("Unable to open");
 ///
 /// # let _ = &mut port;
 /// ```

--- a/src/posix/tty.rs
+++ b/src/posix/tty.rs
@@ -51,14 +51,10 @@ fn close(fd: RawFd) {
 /// use serialport::{TTYPort, SerialPort};
 ///
 /// let (mut master, mut slave) = TTYPort::pair().expect("Unable to create ptty pair");
-///
 /// # let _ = &mut master;
 /// # let _ = &mut slave;
-///
 /// // ... elsewhere
-///
 /// let mut port = TTYPort::open(&serialport::new(slave.name().unwrap(), 0)).expect("Unable to open");
-///
 /// # let _ = &mut port;
 /// ```
 #[derive(Debug)]

--- a/src/posix/tty.rs
+++ b/src/posix/tty.rs
@@ -37,8 +37,9 @@ fn close(fd: RawFd) {
 /// should not be instantiated directly by using `TTYPort::open()`.
 /// Instead, use the cross-platform `serialport::new()`. Example:
 ///
-/// ```
+/// ```no_run
 /// let mut port = serialport::new("/dev/ttyS0", 115200).open().expect("Unable to open");
+/// # let _ = &mut port;
 /// ```
 ///
 /// Note: on macOS, when connecting to a pseudo-terminal (`pty` opened via


### PR DESCRIPTION
Hey 🪼,

this aims to fix #180.
This change alters the comment around the `TTYPort` struct. It removes mentions of old functions/methods no longer in the code base. It adds a tiny example on how to open a tty port the correct way.

Additionally: Sneaks in a tiny fix for an spelling error further down the comment.

I am unsure how to test my change. I think it is important someone rebuilds the docs and checks that my code block is rendered as expected.