### PR TITLE
Pin sub-dependecy of clap to be compatible with MSRV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,11 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 assert_hex = "0.4.1"
 clap = { version = "3.1.6", features = ["derive"] }
 envconfig = "0.10.0"
+# TODO: Remove pinning this subdependency of clap when we are bumping our MSRV.
+# (There has been an incompatible change with the MSRV of os_str_bytes with
+# 6.6.0) Until then we are tricking the dependency resolver into using a
+# compatible version by adding it as a direct dependency here.
+os_str_bytes = ">=6.0, <6.6.0"
 rstest = { version = "0.12.0", default-features = false }
 rustversion = "1.0.16"
 


### PR DESCRIPTION
Fix building from a fresh start with our current MSRV 1.59.0. There has been an incompatible change with respect to the MSRV in _os_str_bytes_ with the minor version update to 6.6.0.

As of 83fd7fb this fails with:
```
$ rm -r target Cargo.lock
$ export SERIALPORT_RS_TEST_PORT_1=DUMMY_1
$ export SERIALPORT_RS_TEST_PORT_2=DUMMY_2
cargo +1.59.0 test --features ignore-hardware-tests
error: package `os_str_bytes v6.6.1` cannot be built because it requires rustc 1.61.0 or newer, while the currently active rustc version is 1.59.0
```

This PR adds a direct dependency to _os_str_bytes_ for tricking the dependency resolution into using a compatible version.