### PR TITLE
Fix intermittent failures with CI build and clean up

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -84,7 +84,7 @@ jobs:
           toolchain: ${{ inputs.toolchain }}
 
       - name: Build | rust-cache
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
 
       - name: Build | build library (default features)
         run: cargo build --target=${{ inputs.target }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -78,27 +78,19 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Build | install toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
           target: ${{ inputs.target }}
           toolchain: ${{ inputs.toolchain }}
-          default: true
 
       - name: Build | rust-cache
         uses: Swatinem/rust-cache@v1
 
       - name: Build | build library (default features)
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --target=${{ inputs.target }}
+        run: cargo build --target=${{ inputs.target }}
 
       - name: Build | build library (all features)
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --all-features --target=${{ inputs.target }}
+        run: cargo build --all-features --target=${{ inputs.target }}
 
       - name: Build | build examples (default features)
         if: ${{ inputs.disable_extra_builds == false }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ jobs:
           components: clippy, rustfmt
 
       - name: Lint | rust-cache
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
 
       - name: Lint | check formatting
         run: cargo fmt -- --check

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,27 +29,19 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Lint | install toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
           toolchain: stable
-          default: true
           components: clippy, rustfmt
 
       - name: Lint | rust-cache
         uses: Swatinem/rust-cache@v1
 
       - name: Lint | check formatting
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: -- --check
+        run: cargo fmt -- --check
 
       - name: Lint | clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-targets --all-features
+        run: cargo clippy --all-targets --all-features
 
   # --------------------------------------------------------------------------
   # MSRV

--- a/deny.toml
+++ b/deny.toml
@@ -4,6 +4,7 @@
 # * allow - No warning or error will be produced, though in some cases a note
 # will be
 
+[graph]
 # If 1 or more target triples (and optionally, target_features) are specified,
 # only the specified targets will be checked when running `cargo deny check`.
 # This means, if a particular package is only ever used as a target specific
@@ -35,18 +36,14 @@ targets = [
 # More documentation for the advisories section can be found here:
 # https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
 [advisories]
+# Selects the default behavior for checking advisories.
+version = 2
 # The path where the advisory database is cloned/fetched into
 db-path = "~/.cargo/advisory-db"
 # The url(s) of the advisory databases to use
 db-urls = ["https://github.com/rustsec/advisory-db"]
-# The lint level for security vulnerabilities
-vulnerability = "deny"
-# The lint level for unmaintained crates
-unmaintained = "deny"
 # The lint level for crates that have been yanked from their source registry
 yanked = "deny"
-# The lint level for crates with security notices.
-notice = "deny"
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
@@ -72,8 +69,8 @@ ignore = [
 # More documentation for the licenses section can be found here:
 # https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
 [licenses]
-# The lint level for crates which do not have a detectable license
-unlicensed = "deny"
+# Selects the default behavior for checking licenses.
+version = 2
 # List of explicitly allowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
@@ -83,26 +80,6 @@ allow = [
     "Unicode-DFS-2016",
     "BSD-2-Clause",
 ]
-# List of explicitly disallowed licenses
-# See https://spdx.org/licenses/ for list of possible licenses
-# [possible values: any SPDX 3.11 short identifier (+ optional exception)].
-deny = [
-    #"Nokia",
-]
-# Lint level for licenses considered copyleft
-copyleft = "allow"
-# Blanket approval or denial for OSI-approved or FSF Free/Libre licenses
-# * both - The license will be approved if it is both OSI-approved *AND* FSF
-# * either - The license will be approved if it is either OSI-approved *OR* FSF
-# * osi-only - The license will be approved if is OSI-approved *AND NOT* FSF
-# * fsf-only - The license will be approved if is FSF *AND NOT* OSI-approved
-# * neither - This predicate is ignored and the default lint level is used
-allow-osi-fsf-free = "neither"
-# Lint level used when no other predicates are matched
-# 1. License isn't in the allow or deny lists
-# 2. License isn't copyleft
-# 3. License isn't OSI/FSF, or allow-osi-fsf-free = "neither"
-default = "deny"
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the
 # canonical license text of a valid SPDX license file.

--- a/deny.toml
+++ b/deny.toml
@@ -75,10 +75,11 @@ version = 2
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
 allow = [
-    "MIT",
     "Apache-2.0",
-    "Unicode-DFS-2016",
     "BSD-2-Clause",
+    "MIT",
+    "MPL-2.0",
+    "Unicode-DFS-2016",
 ]
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the


### PR DESCRIPTION
There were recently a lot of hiccups with installing rustup for Windows in CI. For example [here](https://github.com/serialport/serialport-rs/actions/runs/9051912721/attempts/4). This PR switches to a current and actively maintained action for installing the Rust toolchain.

The previous issues were intermittent and could be overcome by trying several times. But let's have a less dicey way for running CI checks. This PR also includes cleaning up warnings from issues with outdated configuration and actions.