### PR TITLE
Fix output from example receive_data

### DIFF
--- a/examples/receive_data.rs
+++ b/examples/receive_data.rs
@@ -35,7 +35,10 @@ fn main() {
             println!("Receiving data on {} at {} baud:", &port_name, &baud_rate);
             loop {
                 match port.read(serial_buf.as_mut_slice()) {
-                    Ok(t) => io::stdout().write_all(&serial_buf[..t]).unwrap(),
+                    Ok(t) => {
+                        io::stdout().write_all(&serial_buf[..t]).unwrap();
+                        io::stdout().flush().unwrap();
+                    }
                     Err(ref e) if e.kind() == io::ErrorKind::TimedOut => (),
                     Err(e) => eprintln!("{:?}", e),
                 }


### PR DESCRIPTION
There was no visible output without explicitly flushing stdout on on macOS.