### PR TITLE
Fix USB interface on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 ### Changed
 ### Fixed
+* Fix looking up `UsbPortInfo::interface` on macOS.
+  [#193](https://github.com/serialport/serialport-rs/pull/193)
 ### Removed
 
 

--- a/src/posix/enumerate.rs
+++ b/src/posix/enumerate.rs
@@ -300,7 +300,10 @@ fn get_string_property(device_type: io_registry_entry_t, property: &str) -> Opti
 /// `IOIteratorNext`). Specific properties are extracted for USB devices.
 fn port_type(service: io_object_t) -> SerialPortType {
     let bluetooth_device_class_name = b"IOBluetoothSerialClient\0".as_ptr() as *const c_char;
+    #[cfg(not(feature = "usbportinfo-interface"))]
     let usb_device_class_name = b"IOUSBHostDevice\0".as_ptr() as *const c_char;
+    #[cfg(feature = "usbportinfo-interface")]
+    let usb_device_class_name = b"IOUSBHostInterface\0".as_ptr() as *const c_char;
     let legacy_usb_device_class_name = kIOUSBDeviceClassName;
 
     let maybe_usb_device = get_parent_device_by_type(service, usb_device_class_name)

--- a/src/posix/enumerate.rs
+++ b/src/posix/enumerate.rs
@@ -300,9 +300,6 @@ fn get_string_property(device_type: io_registry_entry_t, property: &str) -> Opti
 /// `IOIteratorNext`). Specific properties are extracted for USB devices.
 fn port_type(service: io_object_t) -> SerialPortType {
     let bluetooth_device_class_name = b"IOBluetoothSerialClient\0".as_ptr() as *const c_char;
-    #[cfg(not(feature = "usbportinfo-interface"))]
-    let usb_device_class_name = b"IOUSBHostDevice\0".as_ptr() as *const c_char;
-    #[cfg(feature = "usbportinfo-interface")]
     let usb_device_class_name = b"IOUSBHostInterface\0".as_ptr() as *const c_char;
     let legacy_usb_device_class_name = kIOUSBDeviceClassName;
 


### PR DESCRIPTION
When the `usbportinfo-interface` feature is enabled on macOS, the `UsbPortInfo::interface` is always `None`. A careful reading of https://developer.apple.com/library/archive/documentation/DeviceDrivers/Conceptual/USBBook/USBOverview/USBOverview.html#//apple_ref/doc/uid/TP40002644-BBIDGCHB indicates that device matching or interface matching needs to be considered on a per-application basis. This PR switches the class to `IOUSBHostInterface` when the feature is enabled, allowing the interface number to be returned.

I am not familiar with macOS, but this seems like a fair compromise without changing the `serialport` APIs to make a distinction between searching for devices and searching for interfaces.