### PR TITLE
Resolve Mac OS setting Prolific Technology adapter

### DIFF
--- a/src/posix/termios.rs
+++ b/src/posix/termios.rs
@@ -97,15 +97,21 @@ pub(crate) fn get_termios(fd: RawFd) -> Result<Termios> {
 }
 
 #[cfg(any(target_os = "ios", target_os = "macos",))]
-pub(crate) fn set_termios(fd: RawFd, termios: &libc::termios, baud_rate: u32) -> Result<()> {
+pub(crate) fn set_termios(fd: RawFd, termios: &mut libc::termios, baud_rate: u32) -> Result<()> {
+
+    let mut ispeed_res = 0;
+    let mut ospeed_res = 0;
+    if baud_rate > 0 {
+        unsafe {
+            ispeed_res = libc::cfsetispeed(&mut *termios, baud_rate as libc::speed_t);
+            ospeed_res = libc::cfsetospeed(&mut *termios, baud_rate as libc::speed_t);
+        }
+    }
+    nix::errno::Errno::result(ispeed_res)?;
+    nix::errno::Errno::result(ospeed_res)?;
+
     let res = unsafe { libc::tcsetattr(fd, libc::TCSANOW, termios) };
     nix::errno::Errno::result(res)?;
-
-    // Note: attempting to set the baud rate on a pseudo terminal via this ioctl call will fail
-    // with the `ENOTTY` error.
-    if baud_rate > 0 {
-        crate::posix::ioctl::iossiospeed(fd, &(baud_rate as libc::speed_t))?;
-    }
 
     Ok(())
 }

--- a/src/posix/tty.rs
+++ b/src/posix/tty.rs
@@ -178,7 +178,7 @@ impl TTYPort {
         #[cfg(not(any(target_os = "ios", target_os = "macos")))]
         termios::set_baud_rate(&mut termios, builder.baud_rate);
         #[cfg(any(target_os = "ios", target_os = "macos"))]
-        termios::set_termios(fd.0, &termios, builder.baud_rate)?;
+        termios::set_termios(fd.0, &mut termios, builder.baud_rate)?;
         #[cfg(not(any(target_os = "ios", target_os = "macos")))]
         termios::set_termios(fd.0, &termios)?;
 
@@ -646,7 +646,7 @@ impl SerialPort for TTYPort {
         let mut termios = termios::get_termios(self.fd)?;
         termios::set_flow_control(&mut termios, flow_control);
         #[cfg(any(target_os = "ios", target_os = "macos"))]
-        return termios::set_termios(self.fd, &termios, self.baud_rate);
+        return termios::set_termios(self.fd, &mut termios, self.baud_rate);
         #[cfg(not(any(target_os = "ios", target_os = "macos")))]
         return termios::set_termios(self.fd, &termios);
     }
@@ -655,7 +655,7 @@ impl SerialPort for TTYPort {
         let mut termios = termios::get_termios(self.fd)?;
         termios::set_parity(&mut termios, parity);
         #[cfg(any(target_os = "ios", target_os = "macos"))]
-        return termios::set_termios(self.fd, &termios, self.baud_rate);
+        return termios::set_termios(self.fd, &mut termios, self.baud_rate);
         #[cfg(not(any(target_os = "ios", target_os = "macos")))]
         return termios::set_termios(self.fd, &termios);
     }
@@ -664,7 +664,7 @@ impl SerialPort for TTYPort {
         let mut termios = termios::get_termios(self.fd)?;
         termios::set_data_bits(&mut termios, data_bits);
         #[cfg(any(target_os = "ios", target_os = "macos"))]
-        return termios::set_termios(self.fd, &termios, self.baud_rate);
+        return termios::set_termios(self.fd, &mut termios, self.baud_rate);
         #[cfg(not(any(target_os = "ios", target_os = "macos")))]
         return termios::set_termios(self.fd, &termios);
     }
@@ -673,7 +673,7 @@ impl SerialPort for TTYPort {
         let mut termios = termios::get_termios(self.fd)?;
         termios::set_stop_bits(&mut termios, stop_bits);
         #[cfg(any(target_os = "ios", target_os = "macos"))]
-        return termios::set_termios(self.fd, &termios, self.baud_rate);
+        return termios::set_termios(self.fd, &mut termios, self.baud_rate);
         #[cfg(not(any(target_os = "ios", target_os = "macos")))]
         return termios::set_termios(self.fd, &termios);
     }


### PR DESCRIPTION
This resolves an issue where the baudrate would not be recognized on Mac OS. The adapter details for the faulty adapter are below:

Device Descriptor
        Descriptor Version Number:   0x0200
        Device Class:   0   (Composite)
        Device Subclass:   0
        Device Protocol:   0
        Device MaxPacketSize:   64
        Device VendorID/ProductID:   0x067B/0x2303   (unknown vendor)
        Device Version Number:   0x0300
        Number of Configurations:   1
        Manufacturer String:   1 "Prolific Technology Inc."
        Product String:   2 "USB-Serial Controller"
        Serial Number String:   0 (none)
        
I tested with other adapters (mostly FTDI adapters) and baudrates and this has not provided me with any adverse side effects.