### PR TITLE
Added support for 1.5 stop bits when reading current port settings

### DIFF
--- a/examples/hardware_check.rs
+++ b/examples/hardware_check.rs
@@ -227,6 +227,7 @@ fn test_single_port(port: &mut dyn serialport::SerialPort, loopback: bool) {
     // Test setting stop bits
     println!("Testing stop bits...");
     stop_bits_check!(port, StopBits::Two);
+    stop_bits_check!(port, StopBits::OnePointFive);
     stop_bits_check!(port, StopBits::One);
 
     // Test bytes to read and write

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,6 +225,9 @@ pub enum StopBits {
     /// One stop bit.
     One,
 
+    /// One and a half stop bits.
+    OnePointFive,
+
     /// Two stop bits.
     Two,
 }
@@ -233,6 +236,7 @@ impl fmt::Display for StopBits {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             StopBits::One => write!(f, "One"),
+            StopBits::OnePointFive => write!(f, "OnePointFive"),
             StopBits::Two => write!(f, "Two"),
         }
     }
@@ -242,6 +246,7 @@ impl From<StopBits> for u8 {
     fn from(value: StopBits) -> Self {
         match value {
             StopBits::One => 1,
+            StopBits::OnePointFive => 1,
             StopBits::Two => 2,
         }
     }

--- a/src/windows/com.rs
+++ b/src/windows/com.rs
@@ -326,6 +326,7 @@ impl SerialPort for COMPort {
         let dcb = dcb::get_dcb(self.handle)?;
         match dcb.StopBits {
             TWOSTOPBITS => Ok(StopBits::Two),
+            ONE5STOPBITS => Ok(StopBits::OnePointFive),
             ONESTOPBIT => Ok(StopBits::One),
             _ => Err(Error::new(
                 ErrorKind::Unknown,

--- a/src/windows/dcb.rs
+++ b/src/windows/dcb.rs
@@ -89,6 +89,7 @@ pub(crate) fn set_parity(dcb: &mut DCB, parity: Parity) {
 pub(crate) fn set_stop_bits(dcb: &mut DCB, stop_bits: StopBits) {
     dcb.StopBits = match stop_bits {
         StopBits::One => ONESTOPBIT,
+        StopBits::OnePointFive => ONE5STOPBITS,
         StopBits::Two => TWOSTOPBITS,
     };
 }


### PR DESCRIPTION
On Windows 11 an Espressif ESP32-S3 module connected via USB defaults to 1.5 stop bits when in JTAG/CDC mode
Currently serialport-rs fails to open a port when it is in this state as the stop bits setting of 1.5 is not supported
This change does not allow 1.5 stop bits to be set but avoids failure to open when the port is already set to 1.5 stop bits