### PR TITLE
fix #196

### DIFF
--- a/src/windows/com.rs
+++ b/src/windows/com.rs
@@ -10,7 +10,7 @@ use winapi::um::handleapi::*;
 use winapi::um::processthreadsapi::GetCurrentProcess;
 use winapi::um::winbase::*;
 use winapi::um::winnt::{
-    DUPLICATE_SAME_ACCESS, FILE_ATTRIBUTE_NORMAL, GENERIC_READ, GENERIC_WRITE, HANDLE,
+    DUPLICATE_SAME_ACCESS, FILE_ATTRIBUTE_NORMAL, GENERIC_READ, GENERIC_WRITE, HANDLE, MAXDWORD,
 };
 
 use crate::windows::dcb;
@@ -243,7 +243,7 @@ impl SerialPort for COMPort {
         let milliseconds = timeout.as_millis();
 
         let mut timeouts = COMMTIMEOUTS {
-            ReadIntervalTimeout: 0,
+            ReadIntervalTimeout: MAXDWORD,
             ReadTotalTimeoutMultiplier: 0,
             ReadTotalTimeoutConstant: milliseconds as DWORD,
             WriteTotalTimeoutMultiplier: 0,


### PR DESCRIPTION
I think that this commit would fix the issue #196

As reported here:
https://learn.microsoft.com/en-us/windows/win32/api/winbase/ns-winbase-commtimeouts

> A value of MAXDWORD, combined with zero values for both the ReadTotalTimeoutConstant and ReadTotalTimeoutMultiplier members, specifies that the read operation is to return immediately with the bytes that have already been received, even if no bytes have been received.