### PR TITLE
Prepare release 4.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,27 @@ project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 ### Added
-* Added conversions between `DataBits`, `StopBits` types and their numeric representations
-* Added `FromStr` implementation for `FlowControl`
+* Add conversions between `DataBits`, `StopBits` types and their numeric
+  representations.
+* Add `FromStr` implementation for `FlowControl`.
+  [#163](https://github.com/serialport/serialport-rs/pull/163)
 ### Changed
+* Several changes for CI hygiene.
 ### Fixed
-* Fixes a bug where `available_ports()` returned disabled devices on Windows.
+* Fix a bug where `available_ports()` returned disabled devices on Windows.
   [#144](https://github.com/serialport/serialport-rs/pull/144)
-* Fixes a bug on Windows where the `WriteTotalTimeoutConstant` field hasn't been
+* Fix a bug on Windows where the `WriteTotalTimeoutConstant` field hasn't been
   configured properly when the `set_timeout` method is called.
   [#124](https://github.com/serialport/serialport-rs/issues/124)
+* Fix a longstanding bug on Windows where timeouts of length zero
+  (`Duration::ZERO`) actually resulted in waiting indefinitely.
+  [#79](https://github.com/serialport/serialport-rs/pull/79)
+* Fix missing modem ports from `available_ports()` on Windows.
+  [#81](https://github.com/serialport/serialport-rs/issues/81)
+  [#84](https://github.com/serialport/serialport-rs/pull/84)
+* Fix MSRV incompatibility with sub-dependency of clap.
+  [#186](https://github.com/serialport/serialport-rs/pull/186)
+
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,22 @@ project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 ### Added
+### Changed
+### Fixed
+### Removed
+
+
+## [4.4.0] - 2024-06-26
+
+### Added
 * Add conversions between `DataBits`, `StopBits` types and their numeric
   representations.
 * Add `FromStr` implementation for `FlowControl`.
   [#163](https://github.com/serialport/serialport-rs/pull/163)
+
 ### Changed
 * Several changes for CI hygiene.
+
 ### Fixed
 * Fix a bug where `available_ports()` returned disabled devices on Windows.
   [#144](https://github.com/serialport/serialport-rs/pull/144)
@@ -28,8 +38,6 @@ project adheres to [Semantic Versioning](https://semver.org/).
 * Fix MSRV incompatibility with sub-dependency of clap.
   [#186](https://github.com/serialport/serialport-rs/pull/186)
 
-
-### Removed
 
 ## [4.3.0] - 2023-12-11
 
@@ -396,7 +404,8 @@ Unreleased, happened due to a user error using `cargo-release`.
 * Initial release.
 
 
-[Unreleased]: https://github.com/serialport/serialport-rs/compare/v4.3.0...HEAD
+[Unreleased]: https://github.com/serialport/serialport-rs/compare/v4.4.0...HEAD
+[4.4.0]: https://github.com/serialport/serialport-rs/compare/v4.3.0...v4.4.0
 [4.3.0]: https://github.com/serialport/serialport-rs/compare/v4.2.2...v4.3.0
 [4.2.2]: https://github.com/serialport/serialport-rs/compare/v4.2.1...v4.2.2
 [4.2.1]: https://github.com/serialport/serialport-rs/compare/v4.2.0...v4.2.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serialport"
-version = "4.3.1-alpha.0"
+version = "4.4.0"
 authors = [
     "Bryant Mairs <bryant@mai.rs>",
     "Jesse Braham <jesse@beta7.io>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serialport"
-version = "4.4.0"
+version = "4.4.1-alpha.0"
 authors = [
     "Bryant Mairs <bryant@mai.rs>",
     "Jesse Braham <jesse@beta7.io>",


### PR DESCRIPTION
With several bug fixes for Windows and especially the long-awaited #79, time has finally come for a new release.