### PR TITLE
Add IntoRawHandle impl for FFI ownership transfer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 ### Added
+
+* Add `IntoRawHandle` implementation for `COMPort`
+  [#199](https://github.com/serialport/serialport-rs/pull/199)
+
 ### Changed
 ### Fixed
 ### Removed

--- a/src/windows/com.rs
+++ b/src/windows/com.rs
@@ -176,6 +176,14 @@ impl FromRawHandle for COMPort {
     }
 }
 
+impl IntoRawHandle for COMPort {
+    fn into_raw_handle(self) -> RawHandle {
+        let Self { handle, .. } = self;
+
+        handle as RawHandle
+    }
+}
+
 impl io::Read for COMPort {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         let mut len: DWORD = 0;


### PR DESCRIPTION
Basically the inverse of `FromRawHandle`. Allows an FFI application to take ownership of the handle without leaking a String if constructed on the Rust side.