### PR TITLE
Remove Regex dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 ### Added
 ### Changed
+* Replace using regex crate for parsing device identification strings for
+  `available_ports` on Windows. This is now done by some bespoke code to
+  significantly reduce build times.
+  [#201](https://github.com/serialport/serialport-rs/pull/201)
 ### Fixed
 ### Removed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,6 @@ core-foundation-sys = "0.8.4"
 io-kit-sys = "0.4.0"
 mach2 = "0.4.1"
 
-[target."cfg(windows)".dependencies]
-regex = "1.5.5"
-
 [target."cfg(windows)".dependencies.winapi]
 version = "0.3.9"
 features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,8 @@ envconfig = "0.10.0"
 # 6.6.0) Until then we are tricking the dependency resolver into using a
 # compatible version by adding it as a direct dependency here.
 os_str_bytes = ">=6.0, <6.6.0"
+quickcheck = "1.0.3"
+quickcheck_macros = "1.0.0"
 rstest = { version = "0.12.0", default-features = false }
 rustversion = "1.0.16"
 

--- a/src/windows/enumerate.rs
+++ b/src/windows/enumerate.rs
@@ -543,6 +543,10 @@ pub fn available_ports() -> Result<Vec<SerialPortInfo>> {
 
 #[test]
 fn test_parsing_usb_port_information() {
+    let madeup_hwid = r"USB\VID_1D50&PID_6018+6&A694CA9&0&0000";
+    let info = parse_usb_port_info(madeup_hwid, None).unwrap();
+    assert_eq!(info.serial_number, Some("A694CA9".to_string()));
+
     let bm_uart_hwid = r"USB\VID_1D50&PID_6018&MI_02\6&A694CA9&0&0000";
     let bm_parent_hwid = r"USB\VID_1D50&PID_6018\85A12F01";
     let info = parse_usb_port_info(bm_uart_hwid, Some(bm_parent_hwid)).unwrap();


### PR DESCRIPTION
Regex being the slowest dependency for my entire project just to do a couple matches has been really bugging me. So I just recreated it.

The main draw back is the Unicode table. I just tried to recreate the semantics of the regex, and this is what it specified (any word character).

This is even lighter weight than regex-lite so I would say this succeeds #168, plus there is no MSRV junk to worry about (wrt dependencies). 

I don't personally believe there is any maintenance burden to it since the matching is pretty straightforward. 

I also added a test to test that we select the second part of serial numbers that are split by "&" as specified in one issue. That test seems to have been updated so that it no longer did that after parent IDs were added.