### PR TITLE
fix(usb): improve robustness of interface field when using IOKit backend

### DIFF
--- a/src/posix/enumerate.rs
+++ b/src/posix/enumerate.rs
@@ -328,7 +328,6 @@ fn port_type(service: io_object_t) -> SerialPortType {
             .and_then(|interface| {
                 get_int_property(interface, "bInterfaceNumber", kCFNumberSInt8Type)
             })
-            .or_else(|| get_int_property(usb_device, "bInterfaceNumber", kCFNumberSInt8Type))
             .map(|x| x as u8),
         })
     } else if get_parent_device_by_type(service, bluetooth_device_class_name).is_some() {

--- a/src/posix/enumerate.rs
+++ b/src/posix/enumerate.rs
@@ -321,8 +321,15 @@ fn port_type(service: io_object_t) -> SerialPortType {
             // https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_driverkit_transport_usb
             // https://developer.apple.com/library/archive/documentation/DeviceDrivers/Conceptual/USBBook/USBOverview/USBOverview.html#//apple_ref/doc/uid/TP40002644-BBCEACAJ
             #[cfg(feature = "usbportinfo-interface")]
-            interface: get_int_property(usb_device, "bInterfaceNumber", kCFNumberSInt8Type)
-                .map(|x| x as u8),
+            interface: get_parent_device_by_type(
+                service,
+                b"IOUSBHostInterface\0".as_ptr() as *const c_char,
+            )
+            .and_then(|interface| {
+                get_int_property(interface, "bInterfaceNumber", kCFNumberSInt8Type)
+            })
+            .or_else(|| get_int_property(usb_device, "bInterfaceNumber", kCFNumberSInt8Type))
+            .map(|x| x as u8),
         })
     } else if get_parent_device_by_type(service, bluetooth_device_class_name).is_some() {
         SerialPortType::BluetoothPort


### PR DESCRIPTION
This PR improves the robustness of the code that finds the USB port interface number. Instead of accessing the nonexistent `IOUSBHostDevice.bInterfaceNumber` property, it accesses `IOUSBHostInterface.bInterfaceNumber`.