### PR TITLE
Add some more test cases for MODALIAS parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,8 @@ envconfig = "0.10.0"
 # 6.6.0) Until then we are tricking the dependency resolver into using a
 # compatible version by adding it as a direct dependency here.
 os_str_bytes = ">=6.0, <6.6.0"
+quickcheck = "1.0.3"
+quickcheck_macros = "1.0.0"
 rstest = { version = "0.12.0", default-features = false }
 rustversion = "1.0.16"
 


### PR DESCRIPTION
This is a follow-up to #170. It includes throwing some random data at parse_modalias at each test run with help of quickcheck.