### PR TITLE
Clean up enumeration on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,19 @@ project adheres to [Semantic Versioning](https://semver.org/).
   [#219](https://github.com/serialport/serialport-rs/pull/219)
 
 ### Changed
+
+* Switched from core-foundation-sys to core-foundation for more conviniently
+  working with Core Foundation types for enumeration on macOS.
+  [#218](https://github.com/serialport/serialport-rs/pull/218)
+
 ### Fixed
 
 * Fix enumeration USB reported as PCI devices which do not have a (short)
   serial number.
   [#160](https://github.com/serialport/serialport-rs/pull/160)
+* Fix ignoring the status of several function calls into Core Foundation on mac
+  OS.
+  [#218](https://github.com/serialport/serialport-rs/pull/218)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-* Switched from core-foundation-sys to core-foundation for more conviniently
+* Switched from core-foundation-sys to core-foundation for more conveniently
   working with Core Foundation types for enumeration on macOS.
   [#218](https://github.com/serialport/serialport-rs/pull/218)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ libudev = { version = "0.3.0", optional = true }
 unescaper = "0.1.3"
 
 [target.'cfg(any(target_os = "ios", target_os = "macos"))'.dependencies]
+core-foundation = "0.10.0"
 core-foundation-sys = "0.8.4"
 io-kit-sys = "0.4.0"
 mach2 = "0.4.1"

--- a/deny.toml
+++ b/deny.toml
@@ -49,6 +49,7 @@ yanked = "deny"
 ignore = [
     "RUSTSEC-2021-0145", # caused by unmaintained atty
     "RUSTSEC-2024-0370", # caused by unmaintained proc-macro-error used by some examples
+    "RUSTSEC-2024-0375", # caused by umnaintained atty (again, with migration hint)
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories

--- a/deny.toml
+++ b/deny.toml
@@ -48,6 +48,7 @@ yanked = "deny"
 # output a note when they are encountered.
 ignore = [
     "RUSTSEC-2021-0145", # caused by unmaintained atty
+    "RUSTSEC-2024-0370", # caused by unmaintained proc-macro-error used by some examples
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories

--- a/src/posix/enumerate.rs
+++ b/src/posix/enumerate.rs
@@ -14,7 +14,7 @@ cfg_if! {
         use core_foundation::dictionary::CFMutableDictionary;
         use core_foundation::number::CFNumber;
         use core_foundation::string::CFString;
-        use core_foundation_sys::base::*;
+        use core_foundation_sys::base::{kCFAllocatorDefault, CFRetain};
         use io_kit_sys::*;
         use io_kit_sys::keys::*;
         use io_kit_sys::serial::keys::*;


### PR DESCRIPTION
I spotted missing checks for the returned status for several Core Foundation and IOKit function calls. While looking into this and adding checks, I came across the core-foundation crate which comes in handy for getting less verbose with basic operation with Core Foundation types.

The commit history shows the initial adding of checks and the later migration to core-foundation.