### PR TITLE
usbportinfo: document interface variation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 ### Added
+
+* Add recommendation on how to interpret `UsbPortInfo::interface_number`.
+  [#219](https://github.com/serialport/serialport-rs/pull/219)
+
 ### Changed
 ### Fixed
 ### Removed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -787,7 +787,9 @@ pub struct UsbPortInfo {
     pub manufacturer: Option<String>,
     /// Product name (arbitrary string)
     pub product: Option<String>,
-    /// Interface (id number for multiplexed devices)
+    /// The interface index of the USB port. This can be either the interface number of
+    /// the communication interface (as is the case on Windows and Linux) or the data
+    /// interface (as is the case on macOS), so you should recognize both interface numbers.
     #[cfg(feature = "usbportinfo-interface")]
     pub interface: Option<u8>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -787,7 +787,7 @@ pub struct UsbPortInfo {
     pub manufacturer: Option<String>,
     /// Product name (arbitrary string)
     pub product: Option<String>,
-    /// The interface index of the USB port. This can be either the interface number of
+    /// The interface index of the USB serial port. This can be either the interface number of
     /// the communication interface (as is the case on Windows and Linux) or the data
     /// interface (as is the case on macOS), so you should recognize both interface numbers.
     #[cfg(feature = "usbportinfo-interface")]


### PR DESCRIPTION
Document that the interface number can vary depending on the platform. This addresses some surprise discovered in #214, as it isn't entirely clear which interface should be used, but it is definitely clear that different platforms report differing interface indexes.