### PR TITLE
linux: support getting usb port info without libudev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ project adheres to [Semantic Versioning](https://semver.org/).
 
 * Add recommendation on how to interpret `UsbPortInfo::interface_number`.
   [#219](https://github.com/serialport/serialport-rs/pull/219)
+* Add support for retrieving USB port info on Linux without libudev.
+  [#220](https://github.com/serialport/serialport-rs/pull/220)
 
 ### Changed
 

--- a/examples/list_ports.rs
+++ b/examples/list_ports.rs
@@ -9,39 +9,40 @@ fn main() {
                 n => println!("Found {} ports:", n),
             };
             for p in ports {
-                println!("  {}", p.port_name);
+                println!("    {}", p.port_name);
                 match p.port_type {
                     SerialPortType::UsbPort(info) => {
-                        println!("    Type: USB");
-                        println!("    VID:{:04x} PID:{:04x}", info.vid, info.pid);
-                        println!(
-                            "     Serial Number: {}",
-                            info.serial_number.as_ref().map_or("", String::as_str)
-                        );
-                        println!(
-                            "      Manufacturer: {}",
-                            info.manufacturer.as_ref().map_or("", String::as_str)
-                        );
-                        println!(
-                            "           Product: {}",
-                            info.product.as_ref().map_or("", String::as_str)
-                        );
+                        println!("        Type: USB");
+                        println!("        VID: {:04x}", info.vid);
+                        println!("        PID: {:04x}", info.pid);
                         #[cfg(feature = "usbportinfo-interface")]
                         println!(
-                            "         Interface: {}",
+                            "        Interface: {}",
                             info.interface
                                 .as_ref()
                                 .map_or("".to_string(), |x| format!("{:02x}", *x))
                         );
+                        println!(
+                            "        Serial Number: {}",
+                            info.serial_number.as_ref().map_or("", String::as_str)
+                        );
+                        println!(
+                            "        Manufacturer: {}",
+                            info.manufacturer.as_ref().map_or("", String::as_str)
+                        );
+                        println!(
+                            "        Product: {}",
+                            info.product.as_ref().map_or("", String::as_str)
+                        );
                     }
                     SerialPortType::BluetoothPort => {
-                        println!("    Type: Bluetooth");
+                        println!("        Type: Bluetooth");
                     }
                     SerialPortType::PciPort => {
-                        println!("    Type: PCI");
+                        println!("        Type: PCI");
                     }
                     SerialPortType::Unknown => {
-                        println!("    Type: Unknown");
+                        println!("        Type: Unknown");
                     }
                 }
             }

--- a/examples/list_ports.rs
+++ b/examples/list_ports.rs
@@ -2,12 +2,17 @@ use serialport::{available_ports, SerialPortType};
 
 fn main() {
     match available_ports() {
-        Ok(ports) => {
+        Ok(mut ports) => {
+            // Let's output ports in a stable order to facilitate comparing the output from
+            // different runs (on different platforms, with different features, ...).
+            ports.sort_by_key(|i| i.port_name.clone());
+
             match ports.len() {
                 0 => println!("No ports found."),
                 1 => println!("Found 1 port:"),
                 n => println!("Found {} ports:", n),
             };
+
             for p in ports {
                 println!("    {}", p.port_name);
                 match p.port_type {

--- a/src/posix/enumerate.rs
+++ b/src/posix/enumerate.rs
@@ -551,7 +551,6 @@ cfg_if! {
         }
 
         fn read_usb_port_info(device_path: &Path) -> Option<SerialPortType> {
-
             let device_path = device_path
                 .canonicalize()
                 .ok()?;

--- a/src/posix/enumerate.rs
+++ b/src/posix/enumerate.rs
@@ -535,9 +535,9 @@ cfg_if! {
         use std::path::Path;
 
         fn read_file_to_trimmed_string(dir: &Path, file: &str) -> Option<String> {
-            let dir = dir.join(file);
+            let path = dir.join(file);
             let mut s = String::new();
-            File::open(dir).ok()?.read_to_string(&mut s).ok()?;
+            File::open(path).ok()?.read_to_string(&mut s).ok()?;
             Some(s.trim().to_owned())
         }
 


### PR DESCRIPTION
libudev can make cross-compiling difficult, particularly due to its reliance on pkg-config. It is used primarily for enumeration.

Support getting USB port info such as VID and PID when libudev is disabled. This reads this information out of /sys/. If the information cannot be discovered, then the port type will be `Unknown`.

The method of discovery is based on pySerial, which does something similar.