### PR TITLE
Release 4.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ project adheres to [Semantic Versioning](https://semver.org/).
 * Switched from core-foundation-sys to core-foundation for more conveniently
   working with Core Foundation types for enumeration on macOS.
   [#218](https://github.com/serialport/serialport-rs/pull/218)
+* Refactored output from example `list_ports` (alignment and order) for easily
+  comparing different runs.
+  [#220](https://github.com/serialport/serialport-rs/pull/220)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/) and this
 project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+
+### Added
+### Changed
+### Fixed
+### Removed
+
+
+## [4.6.0] - 2024-10-21
+
 ### Added
 
 * Add recommendation on how to interpret `UsbPortInfo::interface_number`.
@@ -30,8 +39,6 @@ project adheres to [Semantic Versioning](https://semver.org/).
 * Fix ignoring the status of several function calls into Core Foundation on mac
   OS.
   [#218](https://github.com/serialport/serialport-rs/pull/218)
-
-### Removed
 
 
 ## [4.5.1] - 2024-09-20
@@ -462,7 +469,8 @@ Unreleased, happened due to a user error using `cargo-release`.
 * Initial release.
 
 
-[Unreleased]: https://github.com/serialport/serialport-rs/compare/v4.5.0...HEAD
+[Unreleased]: https://github.com/serialport/serialport-rs/compare/v4.6.0...HEAD
+[4.6.0]: https://github.com/serialport/serialport-rs/compare/v4.5.1...v4.6.0
 [4.5.1]: https://github.com/serialport/serialport-rs/compare/v4.5.0...v4.5.1
 [4.5.0]: https://github.com/serialport/serialport-rs/compare/v4.4.0...v4.5.0
 [4.4.0]: https://github.com/serialport/serialport-rs/compare/v4.3.0...v4.4.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serialport"
-version = "4.6.0"
+version = "4.6.1-alpha.0"
 authors = [
     "Bryant Mairs <bryant@mai.rs>",
     "Jesse Braham <jesse@beta7.io>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serialport"
-version = "4.5.2-alpha.0"
+version = "4.6.0"
 authors = [
     "Bryant Mairs <bryant@mai.rs>",
     "Jesse Braham <jesse@beta7.io>",


### PR DESCRIPTION
* We've got device information on Linux without libudev and a bigger fix for macOS