### PR TITLE
handle EINTR return code from tcdrain to effectively flush

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ project adheres to [Semantic Versioning](https://semver.org/).
   [#238](https://github.com/serialport/serialport-rs/pull/238)
 
 ### Fixed
+
+* Retry flushing data on `EINTR` up to the ports read/write timeout.
+  [#225](https://github.com/serialport/serialport-rs/pull/225)
+
 ### Removed
 
 


### PR DESCRIPTION
Hi, this PR adds the handling of EINTR return code from `tcdrain`.

If returning EINTR, it does not mean an actual error for the flushing operation and this should be retried.