### PR TITLE
Add bus_id and port_chain field to UsbPortInfo (all platforms)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -787,6 +787,8 @@ pub struct UsbPortInfo {
     pub manufacturer: Option<String>,
     /// Product name (arbitrary string)
     pub product: Option<String>,
+    /// Location (bus_id-a.b string)
+    pub location: String,
     /// The interface index of the USB serial port. This can be either the interface number of
     /// the communication interface (as is the case on Windows and Linux) or the data
     /// interface (as is the case on macOS), so you should recognize both interface numbers.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -787,8 +787,10 @@ pub struct UsbPortInfo {
     pub manufacturer: Option<String>,
     /// Product name (arbitrary string)
     pub product: Option<String>,
-    /// Location (bus_id-a.b string)
-    pub location: String,
+    /// Device's bus id
+    pub bus_id: String,
+    /// Physycal port hierarchy
+    pub port_chain: Vec<u8>,
     /// The interface index of the USB serial port. This can be either the interface number of
     /// the communication interface (as is the case on Windows and Linux) or the data
     /// interface (as is the case on macOS), so you should recognize both interface numbers.


### PR DESCRIPTION
Add `bus_id` and `port_chain` field to UsbPortInfo (all platforms)

Implementation taken and adapted from `nusb` crate
