### PR TITLE
Pin libc subdependency for MSRV 1.59.0 and allow successor to Unicode DFS license

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 ### Changed
 ### Fixed
+
+* Pin subdependeny `libc` to maintain compatibility with MSRV 1.59.0.
+  [#229](https://github.com/serialport/serialport-rs/pull/229)
+
 ### Removed
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,11 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 assert_hex = "0.4.1"
 clap = { version = "3.1.6", features = ["derive"] }
 envconfig = "0.10.0"
+# TODES Remove pinning this subdependency (of clap) when we are bumping our
+# MSRV (libc raised its MSRV with a patch release 0.2.167 from 1.19.0 to
+# 1.63.0). Trick the resolver into picking a compatible release of libc by
+# adding it as a direct dependency meanwhile.
+libc = ">=0.2.0, <=0.2.163"
 # TODO: Remove pinning this subdependency of clap when we are bumping our MSRV.
 # (There has been an incompatible change with the MSRV of os_str_bytes with
 # 6.6.0) Until then we are tricking the dependency resolver into using a

--- a/deny.toml
+++ b/deny.toml
@@ -81,6 +81,7 @@ allow = [
     "BSD-2-Clause",
     "MIT",
     "MPL-2.0",
+    "Unicode-3.0",
     "Unicode-DFS-2016",
 ]
 # The confidence threshold for detecting a license from license text.


### PR DESCRIPTION
* The libc crate bumped MSRV from 1.19.0 to 1.63.0 with patch release 0.2.164
    * This breaks our builds (like run [12104758738](https://github.com/serialport/serialport-rs/actions/runs/12104758738)) as we are still using MSRV 1.59.0
    * Adding a direct dependency to massage the dependency resolver into using a compatible version already did the trick with  #186
* In addition the license of the sub dependency unicode-ident got updated
    * We allowed the Unicode DFS license
    * Unicode 3.0 is a successor to Unicode DFS