### PR TITLE
impl `Sync` for `SerialPort` trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -447,7 +447,7 @@ impl SerialPortBuilder {
 ///
 /// This trait is all that's necessary to implement a new serial port driver
 /// for a new platform.
-pub trait SerialPort: Send + io::Read + io::Write {
+pub trait SerialPort: Send + Sync + io::Read + io::Write {
     // Port settings getters
 
     /// Returns the name of this port if it exists.

--- a/src/windows/com.rs
+++ b/src/windows/com.rs
@@ -32,11 +32,9 @@ pub struct COMPort {
     port_name: Option<String>,
 }
 
-// The Windows [`HANDLE`] type is considered safe according to the standard library.
-// See explanation on [`OwnedHandle`] in stdlib for more information.
-//
-// [`HANDLE`]: std::os::windows::raw::HANDLE
-// [`OwnedHandle`]: std::os::windows::io::OwnedHandle
+// The Windows `HANDLE` type is considered safe according to the standard library.
+// See the explanation below in stdlib for more information:
+// https://github.com/rust-lang/rust/blob/f4f0fafd0c7849e162eddbc69fa5fe82dbec28c7/library/std/src/os/windows/io/handle.rs#L111-L115
 //
 // In the future we might want to consider using `OwnedHandle` instead of `HANDLE` directly.
 // At the time of writing, such work is blocked by this crate's MSRV (1.59.0) policy as

--- a/src/windows/com.rs
+++ b/src/windows/com.rs
@@ -32,7 +32,17 @@ pub struct COMPort {
     port_name: Option<String>,
 }
 
+// The Windows [`HANDLE`] type is considered safe according to the standard library.
+// See explanation on [`OwnedHandle`] in stdlib for more information.
+//
+// [`HANDLE`]: std::os::windows::raw::HANDLE
+// [`OwnedHandle`]: std::os::windows::io::OwnedHandle
+//
+// In the future we might want to consider using `OwnedHandle` instead of `HANDLE` directly.
+// At the time of writing, such work is blocked by this crate's MSRV (1.59.0) policy as
+// `OwnedHandle` was stabilized in 1.63.0.
 unsafe impl Send for COMPort {}
+unsafe impl Sync for COMPort {}
 
 impl COMPort {
     /// Opens a COM port as a serial device.


### PR DESCRIPTION
Closes #232 

There are many alternatives that don't involve `unsafe impl`, but I believe this is the simplest one that doesn't involve an MSRV bump, nor should it introduce breakage, at least I hope...

One alternative is to use [`OwnedHandle`](https://doc.rust-lang.org/std/os/windows/io/struct.OwnedHandle.html) provided by stdlib. However, doing so requires an MSRV bump to at least 1.63.0, which I've heard would require a major version bump in this library so I refrained from this approach.