### PR TITLE
Enumerate more subsystems without libudev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 ### Changed
+
+* Enumerate ports from more subsystems on Linux without libudev.
+  [#238](https://github.com/serialport/serialport-rs/pull/238)
+
 ### Fixed
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-* Pin subdependeny `libc` to maintain compatibility with MSRV 1.59.0.
+* Pin subdependency `libc` to maintain compatibility with MSRV 1.59.0.
   [#229](https://github.com/serialport/serialport-rs/pull/229)
 
 

--- a/src/posix/enumerate.rs
+++ b/src/posix/enumerate.rs
@@ -558,6 +558,8 @@ cfg_if! {
             let subsystem = subsystem.file_name()?.to_string_lossy();
 
             match subsystem.as_ref() {
+                // Broadcom SoC UARTs (of Raspberry Pi devices).
+                "amba" => Some(SerialPortType::Unknown),
                 "pci" => Some(SerialPortType::PciPort),
                 "pnp" => Some(SerialPortType::Unknown),
                 "usb" => usb_port_type(&path),


### PR DESCRIPTION
The serialport crate currently has two different port enumeration strategies on Linux: [using libudev](https://github.com/serialport/serialport-rs/blob/22d69ba3105030e29dabf6fa621bdf3467e99f73/src/posix/enumerate.rs#L502) and [manually scanning `/sys/class/tty`](https://github.com/serialport/serialport-rs/blob/22d69ba3105030e29dabf6fa621bdf3467e99f73/src/posix/enumerate.rs#L588).

But there is a discrepancy between the ports returned. For example, the serial ports from a PCI card are not enumerated by the latter. Ports returned with the libudev enumeration on this machine:

```
$ cargo run --target x86_64-unknown-linux-gnu --features usbportinfo-interface --example list_ports
[...]
Found 7 ports:
    /dev/ttyS0
        Type: Unknown
    /dev/ttyS4
        Type: PCI
    /dev/ttyS5
        Type: PCI
    /dev/ttyUSB2
        Type: USB
        VID: 0403
        PID: 6001
        Interface: 00
        Serial Number: FTFOO
        Manufacturer: FTDI
        Product: UT232R
    /dev/ttyUSB3
[...]
```

And the ports returned without:

```
$ cargo run --target x86_64-unknown-linux-musl --no-default-features --features usbportinfo-interface --example list_ports
[...]
Found 5 ports:
    /dev/ttyS0
        Type: Unknown
    /dev/ttyUSB2
        Type: USB
        VID: 0403
        PID: 6001
        Interface: 00
        Serial Number: FTFOO
        Manufacturer: FTDI
        Product: UT232R
    /dev/ttyUSB3
[...]
```

This PR sets out to close this gap by using the device subsystem as criterion whether to report a certain device or not. Previously, presence and contents of the `driver_override` file in the sysfs tree was used but this excluded PCI devices as well as the UARTs of Raspberry Pi devices.

Enumeration of ports without libudev with the changes from this PR:

```
$ cargo run --target x86_64-unknown-linux-musl --no-default-features --features usbportinfo-interface --example list_ports
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.02s
     Running `target/x86_64-unknown-linux-musl/debug/examples/list_ports`
Found 7 ports:
    /dev/ttyS0
        Type: Unknown
    /dev/ttyS4
        Type: PCI
    /dev/ttyS5
        Type: PCI
    /dev/ttyUSB2
        Type: USB
        VID: 0403
        PID: 6001
        Interface: 00
        Serial Number: FTFOO
        Manufacturer: FTDI
        Product: UT232R
    /dev/ttyUSB3
[...]
```

There might be corner cases still not caught by this PR. But it improves the enumeration results for cases which knowingly failed beforehand.