### PR TITLE
Add note about DTR behavior on linux

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -396,6 +396,10 @@ impl SerialPortBuilder {
     }
 
     /// Set data terminal ready (DTR) to the given state when opening the device
+    ///
+    /// Note: On Linux, DTR is automatically set on open. Even if you set `dtr_on_open` to false,
+    /// DTR will be asserted for a short moment when opening the port. This can't be prevented
+    /// without kernel modifications.
     #[must_use]
     pub fn dtr_on_open(mut self, state: bool) -> Self {
         self.dtr_on_open = Some(state);


### PR DESCRIPTION
TL;DR: Linux always sets DTR on open, and you can't prevent that without kernel modifications.

See https://github.com/serialport/serialport-rs/issues/37 for more information, most importantly the linked stack overflow question. When working on #40 about 3 years ago, I verified that this was actually true. A quick search through the kernel git history didn't show any recent change.

The only thing I'm not sure about is if this is true for all serial ports on linux, or if it is driver dependent. So maybe the comment should be less strong? (Eg. "On Linux, DTR may automatically be set on open...")?