### PR TITLE
Fix CI semver check job name

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -112,7 +112,7 @@ jobs:
   # code. The feature groups are used for attempting to cover different
   # backends for a platform (like Linux with and without libudev).
 
-  semver-aarch64-apple-darwin:
+  semver:
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
The job itself is a matrix build and the target name is a leftover from setting it up. See for example https://github.com/serialport/serialport-rs/actions/runs/12921738814/job/36299556248?pr=233.