### PR TITLE
Fix testing features and docs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -85,12 +85,19 @@ jobs:
       - name: Build | build library (default features)
         run: cargo build --target=${{ inputs.target }}
 
+      - name: Build | build library (no default features)
+        run: cargo build --no-default-features --target=${{ inputs.target }}
+
       - name: Build | build library (all features)
         run: cargo build --all-features --target=${{ inputs.target }}
 
       - name: Build | build examples (default features)
         if: ${{ inputs.disable_extra_builds == false }}
         run: cargo build --examples --target=${{ inputs.target }}
+
+      - name: Build | build examples (no default features)
+        if: ${{ inputs.disable_extra_builds == false }}
+        run: cargo build --no-default-features --examples --target=${{ inputs.target }}
 
       - name: Build | build examples (all features)
         if: ${{ inputs.disable_extra_builds == false }}
@@ -102,13 +109,20 @@ jobs:
 
       - name: Build | run tests (default features)
         if: ${{ inputs.disable_tests == false }}
-        run: cargo test --no-fail-fast --features ignore-hardware-tests --target=${{ inputs.target }}
+        run: cargo test --no-fail-fast --target=${{ inputs.target }}
 
-      - name: Build | build tests (all features)
+      - name: Build | build tests (no default features)
         if: ${{ inputs.disable_extra_builds == false }}
-        run: cargo build --tests --all-features --target=${{ inputs.target }}
+        run: cargo build --tests --no-default-features --target=${{ inputs.target }}
 
-      - name: Build | run tests (all features)
+      - name: Build | run tests (no default features)
         if: ${{ inputs.disable_tests == false }}
-        # Enabling all features includes ignoring hardware tests.
-        run: cargo test --no-fail-fast --all-features --target=${{ inputs.target }}
+        run: cargo test --no-default-features --no-fail-fast --target=${{ inputs.target }}
+
+      - name: Build | build tests (selected features)
+        if: ${{ inputs.disable_extra_builds == false }}
+        run: cargo build --tests --features libudev,usbportinfo-interface --target=${{ inputs.target }}
+
+      - name: Build | run tests (selected features)
+        if: ${{ inputs.disable_tests == false }}
+        run: cargo test --no-fail-fast --features libudev,usbportinfo-interface --target=${{ inputs.target }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ rustversion = "1.0.16"
 
 [features]
 default = ["libudev"]
-ignore-hardware-tests = []
+hardware-tests = []
 # TODO: Make the feature unconditionally available with the next major release
 # (5.0) and remove this feature gate.
 usbportinfo-interface = []

--- a/TESTING.md
+++ b/TESTING.md
@@ -18,6 +18,12 @@ With two devices connected to each other:
  * `cargo run --example hardware_check <DEVICE1> --loopback-port <DEVICE2>`
  * Also `cargo run --example heartbeat <DEVICE1> <BAUD>` in one terminal and
    `cargo run --example receive_data <DEVICE2> <BAUD>` in another
+ * Running tests with test cases requiring hardware devices enabled:
+     ```
+     $ export SERIALPORT_TEST_PORT_1=$(realpath /dev/ttyX)
+     $ export SERIALPORT_TEST_PORT_2=$(realpath /dev/ttyY)
+     $ cargo test --features hardware-tests
+     ```
 
 Can also verify trickier settings (like non-standard baud rates) using serial terminal programs
 like:

--- a/tests/test_baudrate.rs
+++ b/tests/test_baudrate.rs
@@ -41,7 +41,7 @@ mod builder {
     use super::*;
 
     #[apply(standard_baud_rates)]
-    #[cfg_attr(feature = "ignore-hardware-tests", ignore)]
+    #[cfg_attr(not(feature = "hardware-tests"), ignore)]
     fn test_standard_baud_rate(hw_config: HardwareConfig, #[case] baud: u32) {
         let port = serialport::new(hw_config.port_1, RESET_BAUD_RATE)
             .baud_rate(baud)
@@ -53,7 +53,7 @@ mod builder {
     #[apply(non_standard_baud_rates)]
     #[cfg_attr(
         any(
-            feature = "ignore-hardware-tests",
+            not(feature = "hardware-tests"),
             not(all(target_os = "linux", target_env = "musl")),
         ),
         ignore
@@ -71,7 +71,7 @@ mod builder {
     #[apply(non_standard_baud_rates)]
     #[cfg_attr(
         any(
-            feature = "ignore-hardware-tests",
+            not(feature = "hardware-tests"),
             all(target_os = "linux", target_env = "musl"),
         ),
         ignore
@@ -93,7 +93,7 @@ mod new {
     use super::*;
 
     #[apply(standard_baud_rates)]
-    #[cfg_attr(feature = "ignore-hardware-tests", ignore)]
+    #[cfg_attr(not(feature = "hardware-tests"), ignore)]
     fn test_standard_baud_rate(hw_config: HardwareConfig, #[case] baud: u32) {
         let port = serialport::new(hw_config.port_1, baud).open().unwrap();
         check_baud_rate(port.as_ref(), baud);
@@ -102,7 +102,7 @@ mod new {
     #[apply(non_standard_baud_rates)]
     #[cfg_attr(
         any(
-            feature = "ignore-hardware-tests",
+            not(feature = "hardware-tests"),
             not(all(target_os = "linux", target_env = "musl")),
         ),
         ignore
@@ -117,7 +117,7 @@ mod new {
     #[apply(non_standard_baud_rates)]
     #[cfg_attr(
         any(
-            feature = "ignore-hardware-tests",
+            not(feature = "hardware-tests"),
             all(target_os = "linux", target_env = "musl"),
         ),
         ignore
@@ -136,7 +136,7 @@ mod set_baud {
     use super::*;
 
     #[apply(standard_baud_rates)]
-    #[cfg_attr(feature = "ignore-hardware-tests", ignore)]
+    #[cfg_attr(not(feature = "hardware-tests"), ignore)]
     fn test_standard_baud_rate(hw_config: HardwareConfig, #[case] baud: u32) {
         let mut port = serialport::new(hw_config.port_1, RESET_BAUD_RATE)
             .open()
@@ -150,7 +150,7 @@ mod set_baud {
     #[apply(non_standard_baud_rates)]
     #[cfg_attr(
         any(
-            feature = "ignore-hardware-tests",
+            not(feature = "hardware-tests"),
             not(all(target_os = "linux", target_env = "musl")),
         ),
         ignore
@@ -171,7 +171,7 @@ mod set_baud {
     #[apply(non_standard_baud_rates)]
     #[cfg_attr(
         any(
-            feature = "ignore-hardware-tests",
+            not(feature = "hardware-tests"),
             all(target_os = "linux", target_env = "musl"),
         ),
         ignore

--- a/tests/test_serialport.rs
+++ b/tests/test_serialport.rs
@@ -7,7 +7,7 @@ use serialport::*;
 use std::time::Duration;
 
 #[rstest]
-#[cfg_attr(feature = "ignore-hardware-tests", ignore)]
+#[cfg_attr(not(feature = "hardware-tests"), ignore)]
 fn test_listing_ports() {
     let ports = serialport::available_ports().expect("No ports found!");
     for p in ports {
@@ -16,7 +16,7 @@ fn test_listing_ports() {
 }
 
 #[rstest]
-#[cfg_attr(feature = "ignore-hardware-tests", ignore)]
+#[cfg_attr(not(feature = "hardware-tests"), ignore)]
 fn test_opening_found_ports(hw_config: HardwareConfig) {
     // There is no guarantee that we even might open the ports returned by `available_ports`. But
     // the ports we are using for testing shall be among them.
@@ -26,13 +26,13 @@ fn test_opening_found_ports(hw_config: HardwareConfig) {
 }
 
 #[rstest]
-#[cfg_attr(feature = "ignore-hardware-tests", ignore)]
+#[cfg_attr(not(feature = "hardware-tests"), ignore)]
 fn test_opening_port(hw_config: HardwareConfig) {
     serialport::new(hw_config.port_1, 9600).open().unwrap();
 }
 
 #[rstest]
-#[cfg_attr(feature = "ignore-hardware-tests", ignore)]
+#[cfg_attr(not(feature = "hardware-tests"), ignore)]
 fn test_opening_native_port(hw_config: HardwareConfig) {
     serialport::new(hw_config.port_1, 9600)
         .open_native()
@@ -40,7 +40,7 @@ fn test_opening_native_port(hw_config: HardwareConfig) {
 }
 
 #[rstest]
-#[cfg_attr(feature = "ignore-hardware-tests", ignore)]
+#[cfg_attr(not(feature = "hardware-tests"), ignore)]
 fn test_configuring_ports(hw_config: HardwareConfig) {
     serialport::new(hw_config.port_1, 9600)
         .data_bits(DataBits::Five)
@@ -53,7 +53,7 @@ fn test_configuring_ports(hw_config: HardwareConfig) {
 }
 
 #[rstest]
-#[cfg_attr(feature = "ignore-hardware-tests", ignore)]
+#[cfg_attr(not(feature = "hardware-tests"), ignore)]
 fn test_duplicating_port_config(hw_config: HardwareConfig) {
     let port1_config = serialport::new(hw_config.port_1, 9600)
         .data_bits(DataBits::Five)

--- a/tests/test_timeout.rs
+++ b/tests/test_timeout.rs
@@ -13,7 +13,7 @@ use std::time::{Duration, Instant};
     20,
     Vec::from(b"0123456789:;<=>?@abcdefghijklmnopqrstuvwxyz[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~")
 )]
-#[cfg_attr(feature = "ignore-hardware-tests", ignore)]
+#[cfg_attr(not(feature = "hardware-tests"), ignore)]
 fn test_read_returns_available_data_before_timeout(
     hw_config: HardwareConfig,
     #[case] chunk_size: usize,
@@ -92,7 +92,7 @@ fn test_read_returns_available_data_before_timeout(
 #[case(b"a")]
 #[case(b"0123456789")]
 #[case(b"0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~")]
-#[cfg_attr(feature = "ignore-hardware-tests", ignore)]
+#[cfg_attr(not(feature = "hardware-tests"), ignore)]
 fn test_timeout_zero(hw_config: HardwareConfig, #[case] message: &[u8]) {
     let timeout = Duration::ZERO;
     let margin = Duration::from_millis(100);
@@ -142,7 +142,7 @@ fn test_timeout_zero(hw_config: HardwareConfig, #[case] message: &[u8]) {
 #[case(Duration::from_millis(10))]
 #[case(Duration::from_millis(100))]
 #[case(Duration::from_millis(1000))]
-#[cfg_attr(feature = "ignore-hardware-tests", ignore)]
+#[cfg_attr(not(feature = "hardware-tests"), ignore)]
 fn test_timeout_greater_zero(hw_config: HardwareConfig, #[case] timeout: Duration) {
     let margin = Duration::from_millis(100);
 
@@ -182,7 +182,7 @@ fn test_timeout_greater_zero(hw_config: HardwareConfig, #[case] timeout: Duratio
 /// Checks that reading data with a timeout of `Duration::MAX` returns some data and no error. It
 /// does not check the actual timeout for obvious reason.
 #[rstest]
-#[cfg_attr(feature = "ignore-hardware-tests", ignore)]
+#[cfg_attr(not(feature = "hardware-tests"), ignore)]
 fn test_timeout_max(hw_config: HardwareConfig) {
     let sleep = Duration::from_millis(3000);
     let margin = Duration::from_millis(500);


### PR DESCRIPTION
Enabling hardware tests should be an additive feature and it should be documented in `TESTING.md`. This PR addresses #248.