### PR TITLE
Enumerate Bluetooth serial (RFCOMM) devices on Linux too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ project adheres to [Semantic Versioning](https://semver.org/).
 
 * Parsing serial numbers with underscore from Windows HWIDs
   [#253](https://github.com/serialport/serialport-rs/issues/253)
+* Enumerate Bluetooth serial devices (RFCOMM) on Linux too.
+  [#246](https://github.com/serialport/serialport-rs/issues/246)
 
 ### Removed
 

--- a/tests/test_baudrate.rs
+++ b/tests/test_baudrate.rs
@@ -1,12 +1,17 @@
 mod config;
 
+use assert_hex::assert_eq_hex;
 use config::{hw_config, HardwareConfig};
 use rstest::rstest;
 use rstest_reuse::{self, apply, template};
-use serialport::SerialPort;
+use serialport::{ClearBuffer, SerialPort};
 use std::ops::Range;
+use std::time::Duration;
 
 const RESET_BAUD_RATE: u32 = 300;
+const TEST_MESSAGE: &[u8] =
+    b"0123456789:;<=>?@abcdefghijklmnopqrstuvwxyz[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~";
+const TEST_MESSAGE_TIMEOUT: Duration = Duration::from_millis(1000);
 
 /// Returs an acceptance interval for the actual baud rate returned from the device after setting
 /// the supplied value. For example, the CP2102 driver on Linux returns the baud rate actually
@@ -20,6 +25,21 @@ fn check_baud_rate(port: &dyn SerialPort, baud: u32) {
     let accepted = accepted_actual_baud_for(baud);
     let actual = port.baud_rate().unwrap();
     assert!(accepted.contains(&actual));
+}
+
+fn check_test_message(sender: &mut dyn SerialPort, receiver: &mut dyn SerialPort) {
+    // Ignore any "residue" from previous tests.
+    sender.clear(ClearBuffer::All).unwrap();
+    receiver.clear(ClearBuffer::All).unwrap();
+
+    let send_buf = TEST_MESSAGE;
+    let mut recv_buf = [0u8; TEST_MESSAGE.len()];
+
+    sender.write_all(send_buf).unwrap();
+    sender.flush().unwrap();
+
+    receiver.read_exact(&mut recv_buf).unwrap();
+    assert_eq_hex!(recv_buf, send_buf, "Received message does not match sent");
 }
 
 #[template]
@@ -86,6 +106,25 @@ mod builder {
             .unwrap();
         check_baud_rate(port.as_ref(), baud);
     }
+
+    /// Transmits data back and forth as done by the hardware_check example.
+    #[apply(standard_baud_rates)]
+    #[cfg_attr(not(feature = "hardware-tests"), ignore)]
+    fn test_transmit_at_standard_baud_rate(hw_config: HardwareConfig, #[case] baud: u32) {
+        let mut port1 = serialport::new(hw_config.port_1, RESET_BAUD_RATE)
+            .baud_rate(baud)
+            .timeout(TEST_MESSAGE_TIMEOUT)
+            .open()
+            .unwrap();
+        let mut port2 = serialport::new(hw_config.port_2, RESET_BAUD_RATE)
+            .baud_rate(baud)
+            .timeout(TEST_MESSAGE_TIMEOUT)
+            .open()
+            .unwrap();
+
+        check_test_message(&mut *port1, &mut *port2);
+        check_test_message(&mut *port2, &mut *port1);
+    }
 }
 
 /// Test cases for setting the baud rate via [`serialport::new`].
@@ -129,9 +168,26 @@ mod new {
         let port = serialport::new(hw_config.port_1, baud).open().unwrap();
         check_baud_rate(port.as_ref(), baud);
     }
+
+    /// Transmits data back and forth as done by the hardware_check example.
+    #[apply(standard_baud_rates)]
+    #[cfg_attr(not(feature = "hardware-tests"), ignore)]
+    fn test_transmit_at_standard_baud_rate(hw_config: HardwareConfig, #[case] baud: u32) {
+        let mut port1 = serialport::new(hw_config.port_1, baud)
+            .timeout(TEST_MESSAGE_TIMEOUT)
+            .open()
+            .unwrap();
+        let mut port2 = serialport::new(hw_config.port_2, baud)
+            .timeout(TEST_MESSAGE_TIMEOUT)
+            .open()
+            .unwrap();
+
+        check_test_message(&mut *port1, &mut *port2);
+        check_test_message(&mut *port2, &mut *port1);
+    }
 }
 
-/// Test cases for setting the baud rate via [`SerialPort::set_baud`].
+/// Test cases for setting the baud rate via [`SerialPort::set_baud_rate`].
 mod set_baud {
     use super::*;
 
@@ -187,5 +243,25 @@ mod set_baud {
 
         port.set_baud_rate(baud).unwrap();
         check_baud_rate(port.as_ref(), baud);
+    }
+
+    /// Transmits data back and forth as done by the hardware_check example.
+    #[apply(standard_baud_rates)]
+    #[cfg_attr(not(feature = "hardware-tests"), ignore)]
+    fn test_transmit_at_standard_baud_rate(hw_config: HardwareConfig, #[case] baud: u32) {
+        let mut port1 = serialport::new(hw_config.port_1, RESET_BAUD_RATE)
+            .timeout(TEST_MESSAGE_TIMEOUT)
+            .open()
+            .unwrap();
+        let mut port2 = serialport::new(hw_config.port_2, RESET_BAUD_RATE)
+            .timeout(TEST_MESSAGE_TIMEOUT)
+            .open()
+            .unwrap();
+
+        port1.set_baud_rate(baud).unwrap();
+        port2.set_baud_rate(baud).unwrap();
+
+        check_test_message(&mut *port1, &mut *port2);
+        check_test_message(&mut *port2, &mut *port1);
     }
 }


### PR DESCRIPTION
* RFCOMM devices will be enumerated now (see #246)
* There are still issues with timeouts, ...
    * But they are independent from the enumeration
    * And some of them like baud rate setting are likely related to the nature of this connection type
* This PR also drive-by adds a test case for baud rates
* Fixes #246