### PR TITLE
Release 4.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,17 @@ project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 ### Changed
 ### Fixed
+### Removed
+
+
+## [4.7.1] - 2025-03-25
+
+### Fixed
 
 * Parsing serial numbers with underscore from Windows HWIDs
   [#253](https://github.com/serialport/serialport-rs/issues/253)
 * Enumerate Bluetooth serial devices (RFCOMM) on Linux too.
   [#246](https://github.com/serialport/serialport-rs/issues/246)
-
-### Removed
 
 
 ## [4.7.0] - 2025-01-13
@@ -499,7 +503,8 @@ Unreleased, happened due to a user error using `cargo-release`.
 * Initial release.
 
 
-[Unreleased]: https://github.com/serialport/serialport-rs/compare/v4.7.0...HEAD
+[Unreleased]: https://github.com/serialport/serialport-rs/compare/v4.7.1...HEAD
+[4.7.1]: https://github.com/serialport/serialport-rs/compare/v4.7.0...v4.7.1
 [4.7.0]: https://github.com/serialport/serialport-rs/compare/v4.6.1...v4.7.0
 [4.6.1]: https://github.com/serialport/serialport-rs/compare/v4.6.0...v4.6.1
 [4.6.0]: https://github.com/serialport/serialport-rs/compare/v4.5.1...v4.6.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serialport"
-version = "4.7.1"
+version = "4.7.2-alpha.0"
 authors = [
     "Bryant Mairs <bryant@mai.rs>",
     "Jesse Braham <jesse@beta7.io>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serialport"
-version = "4.7.1-alpha.0"
+version = "4.7.1"
 authors = [
     "Bryant Mairs <bryant@mai.rs>",
     "Jesse Braham <jesse@beta7.io>",


### PR DESCRIPTION
* The two low hanging fixes #254 and #255 have been integrated since then
* It has been some time since the last release
* Let's cut a patch release then
* A new release will get semver checks back on track as this release contains a semver-breaking change wit respect the feature for enabling/disabling hardware tests (and not relevant for normal use of this crate)