### PR TITLE
Add support for absolute paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,13 @@ project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 ### Added
+
+* Add support for opening serial ports on windows with an absolute path.
+  [#259](https://github.com/serialport/serialport-rs/pull/259)
+
 ### Changed
 ### Fixed
 ### Removed
-
 
 ## [4.5.1] - 2024-09-20
 

--- a/src/windows/com.rs
+++ b/src/windows/com.rs
@@ -52,7 +52,10 @@ impl COMPort {
     pub fn open(builder: &SerialPortBuilder) -> Result<COMPort> {
         let mut name = Vec::<u16>::with_capacity(4 + builder.path.len() + 1);
 
-        name.extend(r"\\.\".encode_utf16());
+        if !builder.path.starts_with('\\') {
+            name.extend(r"\\.\".encode_utf16());
+        }
+
         name.extend(builder.path.encode_utf16());
         name.push(0);
 


### PR DESCRIPTION
On Windows, attempting to open a serial port using a Device Interface Path instead of a traditional COMx port name results in a failure.

For instance: trying to open `\\?\USB#VID_0483&PID_5740#158133603236#{86e0d1e0-8089-11d0-9ce4-08003e301f73}` will fail.


Fixes: [#258](https://github.com/serialport/serialport-rs/issues/258)