### PR TITLE
Set DTR on opening a port on best-effort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 ### Changed
 ### Fixed
+
+* Set data terminal ready (DTR) on best-effort for not failing in the situation
+  where we can't detect whether to apply this setting reliably.
+  [#268](https://github.com/serialport/serialport-rs/pull/268)
+
 ### Removed
 
 

--- a/src/posix/tty.rs
+++ b/src/posix/tty.rs
@@ -192,10 +192,11 @@ impl TTYPort {
             baud_rate: builder.baud_rate,
         };
 
-        // Ignore setting DTR for pseudo terminals (indicated by baud_rate == 0).
+        // Ignore setting DTR for pseudo terminals. This might be indicated by baud_rate == 0, but
+        // as this is not always the case, just try on best-effort.
         if builder.baud_rate > 0 {
             if let Some(dtr) = builder.dtr_on_open {
-                port.write_data_terminal_ready(dtr)?;
+                let _ = port.write_data_terminal_ready(dtr);
             }
         }
 

--- a/src/windows/com.rs
+++ b/src/windows/com.rs
@@ -85,8 +85,9 @@ impl COMPort {
         dcb::set_flow_control(&mut dcb, builder.flow_control);
         dcb::set_dcb(handle, dcb)?;
 
+        // Try to set DTR on best-effort.
         if let Some(dtr) = builder.dtr_on_open {
-            com.write_data_terminal_ready(dtr)?;
+            let _ = com.write_data_terminal_ready(dtr);
         }
 
         com.set_timeout(builder.timeout)?;


### PR DESCRIPTION
* There are cases where this might fail and we are not able to detect reliably at present. As as this feature is more on the convenience side, make it not failing opening a serial port.
* Fixes #262