### PR TITLE
Fix CI builds for x86_64-pc-windows-gnu (by sacrificing i686-pc-windows-gnu)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -65,7 +65,7 @@ jobs:
           sudo apt-get -qq -y install build-essential curl git pkg-config ${{ inputs.extra_packages }}
 
       - name: Build | add mingw32 to path
-        if: inputs.runs_on == 'windows-2019'
+        if: inputs.runs_on == 'windows-2025'
         shell: bash
         run: |
           echo "C:\msys64\mingw32\bin" >> $GITHUB_PATH

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -208,12 +208,6 @@ jobs:
       disable_tests: true
       target: armv7-linux-androideabi
 
-  i686-pc-windows-gnu:
-    uses: ./.github/workflows/build.yaml
-    with:
-      runs_on: windows-2025
-      target: i686-pc-windows-gnu
-
   i686-pc-windows-msvc:
     uses: ./.github/workflows/build.yaml
     with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -93,7 +93,7 @@ jobs:
     with:
       disable_extra_builds: true
       disable_tests: true
-      runs_on: windows-2019
+      runs_on: windows-2025
       target: x86_64-pc-windows-msvc
       toolchain: "1.59.0"
 
@@ -211,13 +211,13 @@ jobs:
   i686-pc-windows-gnu:
     uses: ./.github/workflows/build.yaml
     with:
-      runs_on: windows-2019
+      runs_on: windows-2025
       target: i686-pc-windows-gnu
 
   i686-pc-windows-msvc:
     uses: ./.github/workflows/build.yaml
     with:
-      runs_on: windows-2019
+      runs_on: windows-2025
       target: i686-pc-windows-msvc
 
   i686-unknown-linux-gnu:
@@ -243,13 +243,13 @@ jobs:
   x86_64-pc-windows-gnu:
     uses: ./.github/workflows/build.yaml
     with:
-      runs_on: windows-2019
+      runs_on: windows-2025
       target: x86_64-pc-windows-gnu
 
   x86_64-pc-windows-msvc:
     uses: ./.github/workflows/build.yaml
     with:
-      runs_on: windows-2019
+      runs_on: windows-2025
       target: x86_64-pc-windows-msvc
 
   x86_64-unknown-freebsd:
@@ -293,7 +293,7 @@ jobs:
     uses: ./.github/workflows/build.yaml
     with:
       continue-on-error: true
-      runs_on: windows-2019
+      runs_on: windows-2025
       target: x86_64-pc-windows-msvc
       toolchain: nightly
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,6 @@ demand.
 - NetBSD
   - `x86_64-unknown-netbsd` (no serial enumeration)
 - Windows
-  - `i686-pc-windows-gnu`
   - `i686-pc-windows-msvc`
   - `x86_64-pc-windows-gnu`
   - `x86_64-pc-windows-msvc`

--- a/deny.toml
+++ b/deny.toml
@@ -20,7 +20,6 @@ targets = [
     { triple = "aarch64-unknown-linux-musl" },
     { triple = "arm-linux-androideabi" },
     { triple = "armv7-linux-androideabi" },
-    { triple = "i686-pc-windows-gnu" },
     { triple = "i686-pc-windows-msvc" },
     { triple = "i686-unknown-linux-gnu" },
     { triple = "i686-unknown-linux-musl" },


### PR DESCRIPTION
Fixes #267 by bumping the CI runner for Windows to `windows-2025`. There were already warnings for the `windows-2019` runner getting deprecated soon (https://github.com/actions/runner-images/issues/12045).

On the new runner, builds for i686-pc-windows-gnu fail. And as my initial attempts to reproduce and resolve this issue locally failed, I'm going to sacrifice this target in CI for having the more recent variant x86_64-pc-windows-gnu working.