### PR TITLE
Add event listener

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,10 +35,26 @@ features = [
     "minwindef", "ntdef", "setupapi", "winbase", "winerror", "winnt",
 ]
 
+[target."cfg(windows)".dependencies.windows-sys]
+version = "0.60"
+optional = true
+features = [
+	"Win32_Foundation",
+	"Win32_Graphics_Gdi",
+	"Win32_Security",
+	"Win32_System_Threading",
+	"Win32_System_LibraryLoader",
+	"Win32_System_Rpc",
+	"Win32_UI_WindowsAndMessaging",
+]
+
 [dependencies]
 cfg-if = "1.0.0"
 scopeguard = "1.1"
 serde = { version = "1.0", features = ["derive"], optional = true }
+futures = { version = "0.3", optional = true }
+crossbeam = { version = "0.8", optional = true }
+parking_lot = { version = "0.12", optional = true }
 
 [dev-dependencies]
 assert_hex = "0.4.1"
@@ -66,3 +82,9 @@ hardware-tests = []
 # TODO: Make the feature unconditionally available with the next major release
 # (5.0) and remove this feature gate.
 usbportinfo-interface = []
+listener = [
+	"dep:windows-sys",
+	"dep:futures",
+	"dep:parking_lot",
+	"dep:crossbeam",
+]

--- a/examples/listener.rs
+++ b/examples/listener.rs
@@ -1,0 +1,28 @@
+use clap::{Arg, Command};
+use futures::StreamExt;
+fn main() {
+    let matches = Command::new("Serialport Example - Listen")
+        .about("listen to Usb Plug and Unplug events")
+        .disable_version_flag(true)
+        .arg(Arg::new("count").help("The number of Usb Plug and Unplug events to listen to"))
+        .get_matches();
+    let count = match matches.value_of("count") {
+        Some(c) => c.parse::<usize>().unwrap(),
+        _ => 2,
+    };
+    futures::executor::block_on(log_events(count));
+}
+
+async fn log_events(count: usize) {
+    println!("listening to {count} events");
+    let mut n = 0;
+    let mut events = serialport::listen("SERIALPORT_DEMO");
+    while let Some(ev) = events.next().await {
+        println!("{:?}", ev);
+        n += 1;
+        if n == count {
+            break;
+        }
+    }
+    println!("demo over");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,8 @@ pub use posix::{BreakDuration, TTYPort};
 mod windows;
 #[cfg(windows)]
 pub use windows::COMPort;
+#[cfg(all(windows, feature = "listener"))]
+pub use windows::Listener;
 
 #[cfg(test)]
 pub(crate) mod tests;
@@ -882,5 +884,20 @@ pub fn available_ports() -> Result<Vec<SerialPortInfo>> {
     Err(Error::new(
         ErrorKind::Unknown,
         "available_ports() not implemented for platform",
+    ))
+}
+
+/// Returns a [`Listener`]
+pub fn listen<N: Into<std::ffi::OsString>>(name: N) -> Listener {
+    #[cfg(unix)]
+    unimplemented!();
+
+    #[cfg(windows)]
+    return crate::windows::listen(name);
+
+    #[cfg(not(any(unix, windows)))]
+    Err(Error::new(
+        ErrorKind::Unknown,
+        "listen() not implemented for platform",
     ))
 }

--- a/src/windows/listener/event.rs
+++ b/src/windows/listener/event.rs
@@ -1,0 +1,316 @@
+use std::{
+    ffi::{c_void, OsString},
+    future::Future,
+    io,
+    os::windows::{
+        ffi::OsStrExt,
+        io::{AsRawHandle, HandleOrNull, OwnedHandle, RawHandle},
+    },
+    pin::Pin,
+    sync::{Arc, Mutex},
+    task::{Context, Poll, Waker},
+    time::Duration,
+};
+
+use windows_sys::Win32::{
+    Foundation::{FALSE, FILETIME, TRUE, WAIT_ABANDONED, WAIT_FAILED, WAIT_OBJECT_0, WAIT_TIMEOUT},
+    System::Threading::{
+        CreateEventW, CreateThreadpoolWait, ResetEvent, SetEvent, SetThreadpoolWait,
+        WaitForSingleObject, WaitForThreadpoolWaitCallbacks, INFINITE, PTP_CALLBACK_INSTANCE,
+        PTP_WAIT,
+    },
+};
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+#[repr(u32)]
+pub enum Error {
+    Timeout = WAIT_TIMEOUT,
+    Abandoned = WAIT_ABANDONED,
+    Failed = WAIT_FAILED,
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::Timeout => write!(f, "Wait timed out"),
+            Error::Abandoned => write!(f, "Wait abandoned"),
+            Error::Failed => write!(f, "Wait failed"),
+            //Error::Io(e) => write!(f, "Wait io => {e}"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+/// Windows CreateEvent creation argument
+///
+/// If this parameter is TRUE, the function creates a manual-reset event object,
+/// which requires the use of the ResetEvent function to set the event state to
+/// nonsignaled. If this parameter is FALSE, the function creates an auto-reset
+/// event object, and the system automatically resets the event state to
+/// nonsignaled after a single waiting thread has been released.
+#[repr(i32)]
+#[derive(PartialEq)]
+pub enum EventReset {
+    Manual = TRUE,
+    Automatic = FALSE,
+}
+
+/// Windows CreateEvent creation argument
+///
+/// If this parameter is TRUE, the initial state of the event object is
+/// signaled; otherwise, it is nonsignaled.
+#[repr(i32)]
+pub enum EventInitialState {
+    Set = TRUE,
+    Unset = FALSE,
+}
+
+#[derive(Debug)]
+pub struct Event(OwnedHandle);
+
+impl Event {
+    /// Create a system event
+    ///
+    /// [CreateEventW](https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-createeventa)
+    pub fn named<O>(name: O, reset: EventReset, state: EventInitialState) -> io::Result<Event>
+    where
+        O: Into<OsString>,
+    {
+        let kernel_name = name
+            .into()
+            .encode_wide()
+            .chain(Some(0).into_iter())
+            .collect::<Vec<_>>();
+        Self::new_raw(kernel_name.as_ptr() as _, reset, state)
+    }
+
+    /// Create a system event with out a name
+    ///
+    /// [CreateEventW](https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-createeventa)
+    pub fn anonymous(reset: EventReset, state: EventInitialState) -> io::Result<Event> {
+        Self::new_raw(std::ptr::null(), reset, state)
+    }
+
+    pub fn new_raw(
+        name: *const u16,
+        reset: EventReset,
+        state: EventInitialState,
+    ) -> io::Result<Event> {
+        unsafe {
+            let raw = CreateEventW(std::ptr::null(), reset as _, state as _, name);
+            let handle = HandleOrNull::from_raw_handle(raw as _);
+            OwnedHandle::try_from(handle).map_err(|_| io::Error::last_os_error())
+        }
+        .map(Self)
+    }
+
+    pub fn set(&self) -> io::Result<()> {
+        match unsafe { SetEvent(self.as_raw_handle() as _) } {
+            FALSE => Err(io::Error::last_os_error()),
+            _ => Ok(()),
+        }
+    }
+
+    pub fn reset(&self) -> io::Result<()> {
+        match unsafe { ResetEvent(self.as_raw_handle() as _) } {
+            FALSE => Err(io::Error::last_os_error()),
+            _ => Ok(()),
+        }
+    }
+
+    pub fn wait(&self, duration: Option<Duration>) -> Result<(), Error> {
+        let dur: u32 = duration.map(|d| d.as_millis() as _).unwrap_or(INFINITE);
+        match unsafe { WaitForSingleObject(self.as_raw_handle() as _, dur as _) } {
+            WAIT_OBJECT_0 => Ok(()),
+            WAIT_ABANDONED => Err(Error::Abandoned),
+            WAIT_FAILED => Err(Error::Failed),
+            WAIT_TIMEOUT => Err(Error::Timeout),
+            // https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-waitforsingleobject#return-value
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl AsRawHandle for Event {
+    fn as_raw_handle(&self) -> RawHandle {
+        self.0.as_raw_handle()
+    }
+}
+
+/// Callback for which to register Wait handlers
+type WaitCallback = unsafe extern "system" fn(PTP_CALLBACK_INSTANCE, *mut c_void, PTP_WAIT, u32);
+
+/// Wait for pending threadpool callbacks, or cancel pending threadpool callbacks
+#[repr(u32)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum WaitPending {
+    /// Wait for pending threadpool callbacks
+    Wait = 0,
+    /// Cancel pending threadpool callbacks
+    Cancel = 1,
+}
+
+#[derive(Default, Debug)]
+struct WaitState {
+    waker: Option<Waker>,
+    result: Option<std::result::Result<(), Error>>,
+}
+
+#[derive(Debug)]
+pub struct WaitPool(PTP_WAIT);
+
+impl WaitPool {
+    /// https://learn.microsoft.com/en-us/windows/win32/api/threadpoolapiset/nf-threadpoolapiset-createthreadpoolwait
+    pub fn new(cx: *mut c_void) -> io::Result<Self> {
+        let result = unsafe { CreateThreadpoolWait(Some(oneshot_callback), cx, std::ptr::null()) };
+        match result {
+            0 => Err(io::Error::last_os_error()),
+            handle => Ok(WaitPool(handle)),
+        }
+    }
+
+    /// Set a wait object on a threadpool which will trigger a wait callback
+    ///
+    /// https://learn.microsoft.com/en-us/windows/win32/api/threadpoolapiset/nf-threadpoolapiset-setthreadpoolwait
+    pub fn start<H: AsRawHandle>(&self, waitable: &H, timeout: Option<Duration>) {
+        let ft = timeout
+            .map(|to| {
+                let ms = to.as_millis();
+                &FILETIME {
+                    dwHighDateTime: (ms >> 32) as u32,
+                    dwLowDateTime: (ms & 0xFFFFFFFF) as u32,
+                } as *const _
+            })
+            .unwrap_or_else(std::ptr::null);
+        unsafe { SetThreadpoolWait(self.0, waitable.as_raw_handle() as _, ft) };
+    }
+
+    /// The wait object will cease to queue new callbacks. Callbacks already queued will still fire
+    ///
+    /// https://learn.microsoft.com/en-us/windows/win32/api/threadpoolapiset/nf-threadpoolapiset-setthreadpoolwait
+    pub fn stop(&self) {
+        let ft = FILETIME {
+            dwLowDateTime: 0,
+            dwHighDateTime: 0,
+        };
+        // Handle == 0 pool will cease to queue new callbacks. existing callbacks still occur
+        unsafe { SetThreadpoolWait(self.0, std::ptr::null_mut(), &ft) };
+    }
+
+    /// Waits for outstanding wait callbacks to complete and optionally cancels pending callbacks
+    /// that have not yet started to execute.
+    ///
+    /// https://learn.microsoft.com/en-us/windows/win32/api/threadpoolapiset/nf-threadpoolapiset-waitforthreadpoolwaitcallbacks
+    pub fn wait(&self, pending: WaitPending) {
+        unsafe { WaitForThreadpoolWaitCallbacks(self.0, pending as _) };
+    }
+}
+
+#[derive(Debug)]
+pub struct Sender {
+    #[allow(unused)]
+    state: Arc<(Mutex<WaitState>, Event)>,
+}
+
+impl Sender {
+    pub fn set(self) -> io::Result<()> {
+        self.state.1.set()
+    }
+}
+
+#[derive(Debug)]
+pub struct Receiver {
+    #[allow(unused)]
+    pool: WaitPool,
+    state: Arc<(Mutex<WaitState>, Event)>,
+}
+
+impl Future for Receiver {
+    type Output = std::result::Result<(), Error>;
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut state = match self.state.0.lock() {
+            Ok(state) => state,
+            Err(_) => return Poll::Ready(Err(Error::Failed)),
+        };
+
+        match state.result {
+            Some(result) => {
+                if let Some(waker) = state.waker.take() {
+                    waker.wake()
+                }
+                Poll::Ready(result)
+            }
+            None => {
+                // Update our waker
+                let new_waker = cx.waker();
+                state.waker = match state.waker.take() {
+                    None => Some(new_waker.clone()),
+                    Some(old_waker) => match old_waker.will_wake(new_waker) {
+                        false => Some(cx.waker().clone()),
+                        true => Some(old_waker),
+                    },
+                };
+                Poll::Pending
+            }
+        }
+    }
+}
+
+fn oneshot() -> io::Result<(Sender, Receiver)> {
+    let event = Event::anonymous(EventReset::Manual, EventInitialState::Unset)?;
+    let state = Arc::new((Mutex::new(WaitState::default()), event));
+    let pool = WaitPool::new(Arc::as_ptr(&state) as _)?;
+    pool.start(&state.1, None);
+    let sender = Sender { state };
+    let receiver = Receiver {
+        state: Arc::clone(&sender.state),
+        pool,
+    };
+    Ok((sender, receiver))
+}
+
+unsafe extern "system" fn oneshot_callback(
+    _instance: PTP_CALLBACK_INSTANCE,
+    context: *mut c_void,
+    _wait: PTP_WAIT,
+    waitresult: u32,
+) {
+    let state = &*(context as *const (Mutex<WaitState>, Event));
+    if let Ok(mut shared) = state.0.lock() {
+        shared.result = match waitresult {
+            WAIT_OBJECT_0 => Some(Ok(())),
+            WAIT_TIMEOUT => Some(Err(Error::Timeout)),
+            _ => panic!("Unsupported kernel argument passed to wait callback!"),
+        };
+        if let Some(waker) = shared.waker.as_ref() {
+            waker.wake_by_ref()
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use futures::FutureExt;
+    #[test]
+    fn test_event_oneshot() {
+        // Create a test waker
+        let waker = futures::task::noop_waker_ref();
+        let mut cx = std::task::Context::from_waker(waker);
+
+        // Create a channel signal
+        let (sender, mut receiver) = super::oneshot().unwrap();
+
+        // Make sure we are pending
+        let poll = receiver.poll_unpin(&mut cx);
+        assert!(poll.is_pending());
+
+        // Make sure we set event and are no longer pending anymore
+        // NOTE we set the time delay to allow kernel some time to drive our future
+        sender.set().unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        let poll = receiver.poll_unpin(&mut cx);
+        assert!(poll.is_ready());
+    }
+}
+use futures::FutureExt;

--- a/src/windows/listener/guid.rs
+++ b/src/windows/listener/guid.rs
@@ -1,0 +1,112 @@
+//! guid
+
+use super::wide::*;
+use std::ffi::OsString;
+use std::fmt::Debug;
+use std::{error, fmt};
+use windows_sys::Win32::System::Rpc::{UuidFromStringW, RPC_S_INVALID_STRING_UUID};
+
+/// Simple error type when we fail to convert a string into a guid
+#[derive(Debug)]
+pub struct InvalidUuidString(Vec<u16>);
+impl error::Error for InvalidUuidString {}
+impl fmt::Display for InvalidUuidString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "invalid uuid string {:?}", self.0)
+    }
+}
+
+#[derive(Copy, Clone, Default)]
+pub struct Guid(pub windows_sys::core::GUID);
+impl Guid {
+    /// Create a new Guid from an OsString. Will return an encoded wide version of the OsString on
+    /// failure
+    pub fn new<S>(s: S) -> Result<Self, InvalidUuidString>
+    where
+        S: Into<OsString>,
+    {
+        let uuid = to_wide(s);
+        let mut me = unsafe { std::mem::zeroed() };
+        let result = unsafe { UuidFromStringW(uuid.as_ptr(), &mut me) };
+        match result {
+            RPC_S_INVALID_STRING_UUID => Err(InvalidUuidString(uuid)),
+            _ => Ok(Self(me)),
+        }
+    }
+
+    /// Unwrap into the inner [`windows_sys::core::GUID`]
+    pub fn into_inner(self) -> windows_sys::core::GUID {
+        self.0
+    }
+}
+
+impl Debug for Guid {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Guid")
+            .field("data1", &self.0.data1)
+            .field("data2", &self.0.data2)
+            .field("data3", &self.0.data3)
+            .field("data4", &self.0.data4)
+            .finish()
+    }
+}
+
+impl PartialEq for Guid {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.data1 == other.0.data1
+            && self.0.data2 == other.0.data2
+            && self.0.data3 == other.0.data3
+            && self.0.data4 == other.0.data4
+    }
+}
+
+impl From<windows_sys::core::GUID> for Guid {
+    fn from(value: windows_sys::core::GUID) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Guid> for windows_sys::core::GUID {
+    fn from(value: Guid) -> Self {
+        value.0
+    }
+}
+
+/// Initializes a `GUID` from literal values.
+#[macro_export]
+macro_rules! guid {
+    (
+        $a:expr,
+        $b:expr,
+        $c:expr,
+        $d:expr
+    ) => {
+        windows_sys::core::GUID {
+            data1: $a,
+            data2: $b,
+            data3: $c,
+            data4: $d,
+        }
+    };
+
+    (
+        $a:expr,
+        $b:expr,
+        $c:expr,
+        $d0:expr,
+        $d1:expr,
+        $d2:expr,
+        $d3:expr,
+        $d4:expr,
+        $d5:expr,
+        $d6:expr,
+        $d7:expr
+    ) => {
+        windows_sys::core::GUID {
+            data1: $a,
+            data2: $b,
+            data3: $c,
+            data4: [$d0, $d1, $d2, $d3, $d4, $d5, $d6, $d7],
+        }
+    };
+}

--- a/src/windows/listener/mod.rs
+++ b/src/windows/listener/mod.rs
@@ -1,0 +1,24 @@
+mod guid;
+mod wide;
+mod wm;
+
+use std::{ffi::OsString, sync::Arc};
+pub use wm::Listener;
+
+pub fn listen<N>(n: N) -> Listener
+where
+    N: Into<OsString>,
+{
+    let name: OsString = n.into();
+    let window = name.clone();
+    let ours = Arc::new(wm::Queue::new());
+    let theirs = Arc::clone(&ours);
+    let jh = std::thread::spawn(move || unsafe {
+        wm::window_dispatcher(name, Arc::into_raw(theirs) as _)
+    });
+    Listener {
+        window,
+        context: ours,
+        join_handle: Some(jh),
+    }
+}

--- a/src/windows/listener/wide.rs
+++ b/src/windows/listener/wide.rs
@@ -1,0 +1,25 @@
+use std::{ffi::OsString, os::windows::ffi::OsStringExt};
+
+/// Convert a u16 array into an OsString.
+///
+/// Safety: The u16 array must be null terminated
+pub unsafe fn from_wide(ptr: *const u16) -> OsString {
+    let mut seek = ptr;
+    loop {
+        if *seek == 0 {
+            break;
+        } else {
+            seek = seek.add(1);
+        }
+    }
+    let len = (seek as usize - ptr as usize) / std::mem::size_of::<u16>();
+    OsString::from_wide(std::slice::from_raw_parts(ptr, len))
+}
+
+pub fn to_wide<O>(s: O) -> Vec<u16>
+where
+    O: Into<OsString>,
+{
+    use std::os::windows::prelude::*;
+    s.into().encode_wide().chain(Some(0).into_iter()).collect()
+}

--- a/src/windows/listener/wm.rs
+++ b/src/windows/listener/wm.rs
@@ -1,0 +1,354 @@
+use crate::guid;
+
+use super::wide::*;
+use crossbeam::queue::SegQueue;
+use futures::Stream;
+use parking_lot::Mutex;
+use std::{
+    cell::OnceCell,
+    ffi::{c_void, OsString},
+    io,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll, Waker},
+    thread::JoinHandle,
+};
+use winapi::um::winuser::PostMessageW;
+use windows_sys::{
+    core::GUID,
+    Win32::{
+        Foundation::{GetLastError, SetLastError, HMODULE, HWND, LPARAM, LRESULT, WPARAM},
+        System::LibraryLoader::GetModuleHandleW,
+        UI::WindowsAndMessaging::{
+            CreateWindowExW, DefWindowProcW, DispatchMessageW, FindWindowW, GetMessageW,
+            GetWindowLongPtrW, RegisterClassExW, RegisterDeviceNotificationW, SetWindowLongPtrW,
+            TranslateMessage, CW_USEDEFAULT, DBT_DEVICEARRIVAL, DBT_DEVICEREMOVECOMPLETE,
+            DBT_DEVTYP_DEVICEINTERFACE, DBT_DEVTYP_PORT, DEVICE_NOTIFY_WINDOW_HANDLE,
+            DEV_BROADCAST_DEVICEINTERFACE_W, DEV_BROADCAST_HDR, DEV_BROADCAST_PORT_W,
+            GWLP_USERDATA, MSG, WM_CLOSE, WM_DESTROY, WM_DEVICECHANGE, WNDCLASSEXW,
+            WS_EX_APPWINDOW, WS_MINIMIZE,
+        },
+    },
+};
+
+/// Create an instance of a DeviceNotifier window.
+///
+/// Safety: name must be a null terminated Wide string, and user_data must be a pointer to an
+/// Arc<SharedQueue>;
+unsafe fn create_window(name: *const u16, user_data: isize) -> io::Result<HWND> {
+    let handle = CreateWindowExW(
+        WS_EX_APPWINDOW,      // styleEx
+        WINDOW_CLASS_NAME,    // class name
+        name,                 // window name
+        WS_MINIMIZE,          // style
+        0,                    // x
+        0,                    // y
+        CW_USEDEFAULT,        // width
+        CW_USEDEFAULT,        // hight
+        std::ptr::null_mut(), // parent
+        std::ptr::null_mut(), // menu
+        hinstance(),          // instance
+        std::ptr::null(),     // data
+    );
+    match handle.is_null() {
+        true => Err(io::Error::last_os_error()),
+        false => {
+            // NOTE a 0 is returned if their is a failure, or if the previous pointer was NULL. To
+            // distinguish if a true error has occured we have to clear any errors and test the
+            // last_os_error == 0 or not.
+            let prev = unsafe {
+                SetLastError(0);
+                SetWindowLongPtrW(handle, GWLP_USERDATA, user_data)
+            };
+            match prev {
+                0 => match unsafe { GetLastError() } as _ {
+                    0 => Ok(handle),
+                    raw => Err(io::Error::from_raw_os_error(raw)),
+                },
+                _ => Ok(handle),
+            }
+        }
+    }
+}
+
+/// Window proceedure for responding to windows messages and listening for device notifications
+unsafe extern "system" fn window_proceedure(
+    hwnd: HWND,
+    msg: u32,
+    wparam: WPARAM,
+    lparam: LPARAM,
+) -> LRESULT {
+    let ptr = GetWindowLongPtrW(hwnd, GWLP_USERDATA) as *const Queue;
+    if !ptr.is_null() {
+        let queue = &*ptr;
+        match msg {
+            WM_DEVICECHANGE => {
+                // Safety: lparam is a DEV_BROADCAST_HDR when msg is WM_DEVICECHANGE
+                match unsafe { parse_event(wparam, lparam) } {
+                    Some(ev) => {
+                        queue.push(ev);
+                        0
+                    }
+                    _ => DefWindowProcW(hwnd, msg, wparam, lparam),
+                }
+            }
+            WM_DESTROY => {
+                // NOTE we only reconstruct our arc on destroy
+                let arc = Arc::from_raw(ptr as *const Queue);
+                arc.done();
+                0
+            }
+            _ => DefWindowProcW(hwnd, msg, wparam, lparam),
+        }
+    } else {
+        DefWindowProcW(hwnd, msg, wparam, lparam)
+    }
+}
+
+unsafe fn parse_event(wparam: WPARAM, lparam: LPARAM) -> Option<Event> {
+    match wparam as u32 {
+        DBT_DEVICEARRIVAL => Some(Event::Arrival(maybe_serialport(lparam as _)?)),
+        DBT_DEVICEREMOVECOMPLETE => Some(Event::RemoveComplete(maybe_serialport(lparam as _)?)),
+        _ => None,
+    }
+}
+
+/// Safety: data must be a DEV_BROADCAST_HDR
+unsafe fn maybe_serialport(data: *mut c_void) -> Option<String> {
+    let broadcast = &mut *(data as *mut DEV_BROADCAST_HDR);
+    match broadcast.dbch_devicetype {
+        DBT_DEVTYP_PORT => {
+            let data = &*(data as *const DEV_BROADCAST_PORT_W);
+            from_wide(data.dbcp_name.as_ptr())
+                .to_str()
+                .map(|port| port.to_string())
+        }
+        _ => None,
+    }
+}
+
+/// Dispatch window messages
+///
+/// We receive a "name", a list of GUID registrations, and some "user_data" which is an arc.
+///
+/// Safety: user_data must be a pointer to an Arc<SharedQueue> that was created
+/// by Arc::into_raw...
+///
+/// This method will rebuild the Arc and pass it to the window procedure...
+pub unsafe fn window_dispatcher(name: OsString, user_data: isize) -> io::Result<()> {
+    const WCEUSBS: GUID =
+        guid!(0x25dbce51, 0x6c8f, 0x4a72, 0x8a, 0x6d, 0xb5, 0x4c, 0x2b, 0x4f, 0xc8, 0x35);
+    const USBDEVICE: GUID =
+        guid!(0x88BAE032, 0x5A81, 0x49f0, 0xBC, 0x3D, 0xA4, 0xFF, 0x13, 0x82, 0x16, 0xD6);
+    const PORTS: GUID =
+        guid!(0x4d36e978, 0xe325, 0x11ce, 0xbf, 0xc1, 0x08, 0x00, 0x2b, 0xe1, 0x03, 0x18);
+    let _atom = get_window_class();
+    let unsafe_name = to_wide(name.clone());
+    let arc = Arc::from_raw(user_data as *const Arc<Queue>);
+    let hwnd = create_window(unsafe_name.as_ptr(), Arc::as_ptr(&arc) as _)?;
+    let _registery = [WCEUSBS, USBDEVICE, PORTS]
+        .into_iter()
+        .map(|guid| {
+            let handle = unsafe {
+                let mut iface = std::mem::zeroed::<DEV_BROADCAST_DEVICEINTERFACE_W>();
+                iface.dbcc_size = std::mem::size_of::<DEV_BROADCAST_DEVICEINTERFACE_W>() as _;
+                iface.dbcc_classguid = guid;
+                iface.dbcc_devicetype = DBT_DEVTYP_DEVICEINTERFACE;
+                RegisterDeviceNotificationW(
+                    hwnd as _,
+                    &iface as *const _ as _,
+                    DEVICE_NOTIFY_WINDOW_HANDLE,
+                )
+            };
+            match handle.is_null() {
+                false => Ok(handle),
+                true => Err(io::Error::last_os_error()),
+            }
+        })
+        .collect::<io::Result<Vec<_>>>()?;
+
+    let mut msg: MSG = std::mem::zeroed();
+    loop {
+        match GetMessageW(&mut msg as *mut _, std::ptr::null_mut(), 0, 0) {
+            0 => {
+                break Ok(());
+            }
+            -1 => {
+                let error = Err(io::Error::last_os_error());
+                break error;
+            }
+            _ if msg.message == WM_CLOSE => {
+                TranslateMessage(&msg as *const _);
+                DispatchMessageW(&msg as *const _);
+                break Ok(());
+            }
+            _ => {
+                TranslateMessage(&msg as *const _);
+                DispatchMessageW(&msg as *const _);
+            }
+        }
+    }
+}
+
+/// The name of our window class.
+/// [See also](https://learn.microsoft.com/en-us/windows/win32/winmsg/about-window-classes)
+const WINDOW_CLASS_NAME: *const u16 = windows_sys::w!("DeviceNotifier");
+
+/// We register our class only once
+const WINDOW_CLASS_ATOM: OnceCell<u16> = OnceCell::new();
+fn get_window_class() -> u16 {
+    *WINDOW_CLASS_ATOM.get_or_init(|| {
+        let class = WNDCLASSEXW {
+            style: 0,
+            hIcon: std::ptr::null_mut(),
+            cbSize: std::mem::size_of::<WNDCLASSEXW>() as _,
+            hIconSm: std::ptr::null_mut(),
+            hCursor: std::ptr::null_mut(),
+            cbClsExtra: 0,
+            cbWndExtra: 0,
+            hInstance: hinstance(),
+            lpszMenuName: std::ptr::null(),
+            lpszClassName: WINDOW_CLASS_NAME,
+            lpfnWndProc: Some(window_proceedure),
+            hbrBackground: std::ptr::null_mut(),
+        };
+        match unsafe { RegisterClassExW(&class as *const _) } {
+            0 => panic!("{:?}", io::Error::last_os_error()),
+            atom => atom,
+        }
+    })
+}
+
+/// Creating Windows requires the hinstance prop of the WinMain function. To retreive this
+/// parameter use [`windows_sys::Win32::System::LibraryLoader::GetModuleHandleW`];
+fn hinstance() -> HMODULE {
+    // Safety: If the handle is NULL, GetModuleHandle returns a handle to the file used to create
+    // the calling process
+    unsafe { GetModuleHandleW(std::ptr::null()) }
+}
+
+/// When a user will Plug or Unplug a Usb Port you will receive an [`Event`]
+///
+/// To get a stream of [`Event`], use [`crate::listen`]
+#[derive(Debug)]
+pub enum Event {
+    /// A Usb has plugged into the system. The string is the name of the Port. IE: COM3
+    Arrival(String),
+    /// A Usb has unplugged from the system. The string is the name of the Port. IE: COM3
+    RemoveComplete(String),
+}
+
+#[derive(Default)]
+pub struct Queue {
+    inner: SegQueue<Option<Event>>,
+    waker: Mutex<Option<Waker>>,
+}
+
+impl Queue {
+    pub fn new() -> Queue {
+        Queue {
+            inner: SegQueue::new(),
+            waker: Mutex::new(None),
+        }
+    }
+
+    pub fn maybe_wake(&self) {
+        if let Some(waker) = &self.waker.lock().as_ref() {
+            waker.wake_by_ref();
+        }
+    }
+
+    pub fn push(&self, ev: Event) {
+        self.inner.push(Some(ev));
+        self.maybe_wake();
+    }
+
+    pub fn done(&self) {
+        self.inner.push(None);
+        self.maybe_wake();
+    }
+
+    pub fn poll_next(&self, cx: &mut Context<'_>) -> Poll<Option<Event>> {
+        match self.inner.pop() {
+            None => {
+                let new_waker = cx.waker();
+                let mut waker = self.waker.lock();
+                *waker = match waker.take() {
+                    None => Some(new_waker.clone()),
+                    Some(old_waker) => {
+                        if old_waker.will_wake(new_waker) {
+                            Some(old_waker)
+                        } else {
+                            Some(new_waker.clone())
+                        }
+                    }
+                };
+                Poll::Pending
+            }
+            Some(Some(inner)) => Poll::Ready(Some(inner)),
+            Some(None) => Poll::Ready(None),
+        }
+    }
+}
+
+/// Stream of [`Event`]
+///
+/// See also [`crate::listen`]
+pub struct Listener {
+    pub(crate) window: OsString,
+    pub(crate) context: Arc<Queue>,
+    pub(crate) join_handle: Option<JoinHandle<io::Result<()>>>,
+}
+
+impl std::fmt::Debug for Listener {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Listener")
+            .field("window", &self.window)
+            .finish()
+    }
+}
+
+impl Listener {
+    /// Stop listening to events
+    pub fn close(&mut self) -> io::Result<()> {
+        // Find the window so we can close it
+        let wide = to_wide(self.window.clone());
+        let hwnd = unsafe {
+            let result = FindWindowW(WINDOW_CLASS_NAME, wide.as_ptr());
+            match result.is_null() {
+                true => Err(io::Error::last_os_error()),
+                _ => Ok(result),
+            }
+        }?;
+
+        // Close the window
+        let _close = unsafe {
+            let result = PostMessageW(hwnd as _, WM_CLOSE, 0, 0);
+            match result {
+                0 => Err(io::Error::last_os_error()),
+                _ => Ok(()),
+            }
+        }?;
+
+        // Join the thread
+        let jh = self
+            .join_handle
+            .take()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "Already closed WindowEvents"))?;
+        jh.join()
+            .map_err(|_| io::Error::new(io::ErrorKind::Other, "join error"))?
+    }
+}
+
+impl Drop for Listener {
+    fn drop(&mut self) {
+        let _ = self.close();
+    }
+}
+
+impl Stream for Listener {
+    type Item = Event;
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.context.poll_next(cx)
+    }
+}

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -1,7 +1,11 @@
 pub use self::com::*;
 pub use self::enumerate::*;
+#[cfg(feature = "listener")]
+pub use self::listener::*;
 
 mod com;
 mod dcb;
 mod enumerate;
 mod error;
+#[cfg(feature = "listener")]
+mod listener;


### PR DESCRIPTION
It looks like the only way to receive notifications of Usb plug and unplug events is by periodically calling "available_ports()" method.  We can avoid this polling by listening for Usb events using windows messaging on windows, and udev on unix.

This PR currently adds this support for windows. But if there is interest in this PR and the API is satisfactory then I can also add for linux.

The examples/listener output pasted below

<img width="1356" height="361" alt="image" src="https://github.com/user-attachments/assets/3011bf42-f598-4fcf-b085-45c83e7ae5d2" />
