### PR TITLE
Replace `winapi` with `windows-sys` crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 ### Changed
+
+* Switch from no longer actively maintained Windows FFI abstractions winapi
+  to active windows-sys crate.
+  [https://github.com/serialport/serialport-rs/pull/280]
+
 ### Fixed
 ### Removed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,11 +28,19 @@ core-foundation-sys = "0.8.4"
 io-kit-sys = "0.4.0"
 mach2 = "0.4.1"
 
-[target."cfg(windows)".dependencies.winapi]
-version = "0.3.9"
+[target."cfg(windows)".dependencies.windows-sys]
+version = "0.60.2"
 features = [
-    "cguid", "commapi", "errhandlingapi", "fileapi", "guiddef", "handleapi", "minwinbase",
-    "minwindef", "ntdef", "setupapi", "winbase", "winerror", "winnt",
+    "Win32_Devices_Communication",
+    "Win32_Foundation",
+    "Win32_Storage_FileSystem",
+    "Win32_System_IO",
+    "Win32_System_Registry",
+    "Win32_System_Diagnostics_Debug",
+    "Win32_Devices_DeviceAndDriverInstallation",
+    "Win32_System_Threading",
+    "Win32_Security",
+    "Win32_System_SystemServices",
 ]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ io-kit-sys = "0.4.0"
 mach2 = "0.4.1"
 
 [target."cfg(windows)".dependencies.windows-sys]
-version = "0.60.2"
+version = "0.52.0"
 features = [
     "Win32_Devices_Communication",
     "Win32_Foundation",

--- a/deny.toml
+++ b/deny.toml
@@ -81,7 +81,6 @@ allow = [
     "MIT",
     "MPL-2.0",
     "Unicode-3.0",
-    "Unicode-DFS-2016",
 ]
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the


### PR DESCRIPTION
This is another take of https://github.com/serialport/serialport-rs/pull/228.

- Fixes <https://github.com/serialport/serialport-rs/issues/56>
- Closes <https://github.com/serialport/serialport-rs/pull/228>

This PR offers two options:

- [`windows-sys 0.62`](https://crates.io/crates/windows-sys/0.60.2) (requires MSRV bump to 1.60) if only take the first commit
- [`windows-sys 0.52`](https://crates.io/crates/windows-sys/0.52.0) (MSRV 1.52) with both commits

Should you choose not to squash the commits when merging, you can then revert the second commit later when you decide to upgrade the `windows-sys` crate (as upgrading introduces breaking changes) to make it compatible with newer version.

Test results:

- `windows-sys 0.62`: <https://github.com/sola-contrib/serialport-rs/actions/runs/16767971224>
- `windows-sys 0.52`: <https://github.com/sola-contrib/serialport-rs/actions/runs/16769159151>