### PR TITLE
Accept colon in serial number parsing on Windows

### DIFF
--- a/src/windows/enumerate.rs
+++ b/src/windows/enumerate.rs
@@ -715,6 +715,17 @@ mod tests {
                 interface: Some("90"),
             }
         );
+
+        // There are ESP32 Arduino devices using colons in their serial numbers. See issue #279.
+        assert_eq!(
+            HwidMatches::new("USB\\VID_303A&PID_1001\\B4:3A:45:B0:08:24").unwrap(),
+            HwidMatches {
+                vid: "303A",
+                pid: "1001",
+                serial: Some("B4:3A:45:B0:08:24"),
+                interface: None,
+            },
+        )
     }
 
     #[test]

--- a/src/windows/enumerate.rs
+++ b/src/windows/enumerate.rs
@@ -13,7 +13,7 @@ use winapi::um::winreg::*;
 
 use crate::{Error, ErrorKind, Result, SerialPortInfo, SerialPortType, UsbPortInfo};
 
-const CONNECTOR_PUNCTUATION_SELECTION: &[char] = &['_', '\u{ff3f}'];
+const CONNECTOR_PUNCTUATION_SELECTION: &[char] = &[':', '_', '\u{ff3f}'];
 
 /// takes normal Rust `str` and outputs a null terminated UTF-16 encoded string
 fn as_utf16(utf8: &str) -> Vec<u16> {


### PR DESCRIPTION
* Fixes issue #279 by accepting the colon as part of serial numbers when parsing Windows Hardware IDs