### PR TITLE
fix input baudrate not cleared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ project adheres to [Semantic Versioning](https://semver.org/).
   [#29](https://github.com/serialport/serialport-rs/pull/29)
 
 ### Fixed
+
+* Setting arbitrary baud rates on Linux which resulted in issues when read back
+  on Arch recently.
+  [#281](https://github.com/serialport/serialport-rs/issues/281)
+  [#283](https://github.com/serialport/serialport-rs/pull/283)
+
 ### Removed
 
 

--- a/src/posix/termios.rs
+++ b/src/posix/termios.rs
@@ -214,7 +214,7 @@ pub(crate) fn set_stop_bits(termios: &mut Termios, stop_bits: StopBits) {
     )
 ))]
 pub(crate) fn set_baud_rate(termios: &mut Termios, baud_rate: u32) -> Result<()> {
-    termios.c_cflag &= !nix::libc::CBAUD;
+    termios.c_cflag &= !(nix::libc::CBAUD | nix::libc::CIBAUD);
     termios.c_cflag |= nix::libc::BOTHER;
     termios.c_ispeed = baud_rate;
     termios.c_ospeed = baud_rate;


### PR DESCRIPTION
```rust
pub(crate) fn set_baud_rate(termios: &mut Termios, baud_rate: u32) -> Result<()> {
    termios.c_cflag &= !nix::libc::CBAUD;
    termios.c_cflag |= nix::libc::BOTHER;
    termios.c_ispeed = baud_rate;
    termios.c_ospeed = baud_rate;
}
```
`termios.c_cflag &= !nix::libc::CBAUD;` only cleared CBAUD but left CIBAUD untouched. since the termios struct passed in is the one previously read from the kernel, it already contains whatever input baud rate flags were set earlier.

If we don’t clear them, the old CIBAUD sticks around while ospeed gets updated, causing a mismatch: 
```bash
assertion failed: termios2.c_ospeed == termios2.c_ispeed
```
see issue: https://github.com/serialport/serialport-rs/issues/281

This is consistent with glibc implementation (https://github.com/bminor/glibc/blob/35296a6e73d3244b415823e2811fa5f930457944/sysdeps/unix/sysv/linux/cfsetspeed.c#L29)

I verified this change on my own virtual serialport module: https://github.com/33671/vserial/, and it fixed the baudrate mismatch there.
espflash is not tested, but given the similarity to glibc’s approach, this should resolve the issue