### PR TITLE
Don't run doctest for PTY which started failing on Linux

### DIFF
--- a/src/posix/tty.rs
+++ b/src/posix/tty.rs
@@ -47,7 +47,7 @@ fn close(fd: RawFd) {
 /// explicitly _skip_ an attempt to set the baud rate of the file descriptor
 /// that would otherwise happen via an `ioctl` command.
 ///
-/// ```
+/// ```no_run
 /// use serialport::{TTYPort, SerialPort};
 ///
 /// let (mut master, mut slave) = TTYPort::pair().expect("Unable to create ptty pair");


### PR DESCRIPTION
This test illustrates opening a PTY on macOS. It started to fail recently on Linux/musl (#280, #282, #283, ...).

I've found no way to limit its execution just to macOS. And ignoring it via `ignore-linux` feels like this will fail on another POSIX target sooner or later. Keep a low profile and disable actually running this test at all.