### PR TITLE
Update external link for Apple sources

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,6 +42,21 @@ jobs:
         run: cargo clippy --all-targets --all-features
 
   # --------------------------------------------------------------------------
+  # Link checks
+
+  links:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Links | checkout
+        uses: actions/checkout@v2
+
+      - name: Links | check
+        id: lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          fail: true
+
+  # --------------------------------------------------------------------------
   # MSRV
   #
   # Check at least once per platform.

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,3 @@
+# Ignore links to issues on GitLab which are no longer reachable since we
+# disabled bug tracking over there.
+https://gitlab.com/susurrus/serialport-rs/(-/)?merge_requests/\d+

--- a/NOTES.md
+++ b/NOTES.md
@@ -22,7 +22,7 @@ state can always be considered the canonical source.
 
 `iossiospeed` has no official documentation that can be found by searching
 https://developer.apple.com. However
-[IOSerialTestLib.c](https://opensource.apple.com/source/IOSerialFamily/IOSerialFamily-93/tests/IOSerialTestLib.c.auto.html)
+[IOSerialTestLib.c](https://github.com/apple-oss-distributions/IOSerialFamily/blob/1c12ee3d9ec665bb53d0151644408d25e54fe012/tests/IOSerialTestLib.c)
 can be found on Apple's open source code repository and has some example code for using this API.
 
 Experimentation has shown that there are a few key features to using `iossiospeed`:


### PR DESCRIPTION
Link checking reported this one as stale and the nearest relative found so far is the one on GitHub.