### PR TITLE
Pin dependency core-foundation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,8 @@ libudev = { version = "0.3.0", optional = true }
 unescaper = "0.1.3"
 
 [target.'cfg(any(target_os = "ios", target_os = "macos"))'.dependencies]
-core-foundation = "0.10.0"
+# TODO: Remove pinning this dependency when we are bumping our MSRV.
+core-foundation = "=0.10.0"
 core-foundation-sys = "0.8.4"
 io-kit-sys = "0.4.0"
 mach2 = "0.4.1"


### PR DESCRIPTION
Its patch release 0.10.1 bumps the MSRV to 1.65. We need to stay on 0.10.0 requiring just the 2018 edition for our MSRV 1.59.