### PR TITLE
Use `objc2-io-kit`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ project adheres to [Semantic Versioning](https://semver.org/).
 * Output USB VID and PID in hexadecimal digits in `UsbPortInfo`'s `Debug`
   representation.
   [#290](https://github.com/serialport/serialport-rs/pull/290)
+* Migrated away from unmaintainted dependency `mach2`.
 
 
 ## [4.7.3] - 2025-08-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,8 @@ project adheres to [Semantic Versioning](https://semver.org/).
   representation.
   [#290](https://github.com/serialport/serialport-rs/pull/290)
 * Migrated away from unmaintainted dependency `mach2`.
+* Migrated from `io-kit-sys` to `objc2-io-kit`.
+* Migrated from `core-foundation` to `objc2-core-foundation`.
 
 
 ## [4.7.3] - 2025-08-24

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,21 @@ libudev = { version = "0.3.0", optional = true }
 unescaper = "0.1.3"
 
 [target.'cfg(target_vendor = "apple")'.dependencies]
-core-foundation = "0.10.0"
-core-foundation-sys = "0.8.4"
-io-kit-sys = "0.4.0"
+objc2-io-kit = { version = "0.3.2", default-features = false, features = [
+    "std",
+    "libc",
+    "usb",
+    "serial",
+    "IOUSBLib",
+    "IOUSBHostFamilyDefinitions",
+] }
+objc2-core-foundation = { version = "0.3.2", default-features = false, features = [
+    "std",
+    "CFBase",
+    "CFDictionary",
+    "CFNumber",
+    "CFString",
+] }
 
 [target."cfg(windows)".dependencies.windows-sys]
 version = "0.61.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ nix = { version = "0.31.3", default-features = false, features = ["fs", "ioctl",
 libudev = { version = "0.3.0", optional = true }
 unescaper = "0.1.3"
 
-[target.'cfg(any(target_os = "ios", target_os = "macos"))'.dependencies]
+[target.'cfg(target_vendor = "apple")'.dependencies]
 core-foundation = "0.10.0"
 core-foundation-sys = "0.8.4"
 io-kit-sys = "0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ unescaper = "0.1.3"
 core-foundation = "0.10.0"
 core-foundation-sys = "0.8.4"
 io-kit-sys = "0.4.0"
-mach2 = "0.4.1"
 
 [target."cfg(windows)".dependencies.windows-sys]
 version = "0.61.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,13 @@ libudev = { version = "0.3.0", optional = true }
 unescaper = "0.1.3"
 
 [target.'cfg(target_vendor = "apple")'.dependencies]
+objc2-core-foundation = { version = "0.3.2", default-features = false, features = [
+    "std",
+    "CFBase",
+    "CFDictionary",
+    "CFNumber",
+    "CFString",
+] }
 objc2-io-kit = { version = "0.3.2", default-features = false, features = [
     "std",
     "libc",
@@ -30,13 +37,6 @@ objc2-io-kit = { version = "0.3.2", default-features = false, features = [
     "serial",
     "IOUSBLib",
     "IOUSBHostFamilyDefinitions",
-] }
-objc2-core-foundation = { version = "0.3.2", default-features = false, features = [
-    "std",
-    "CFBase",
-    "CFDictionary",
-    "CFNumber",
-    "CFString",
 ] }
 
 [target."cfg(windows)".dependencies.windows-sys]

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ demand.
   - `i686-unknown-linux-musl`
   - `x86_64-unknown-linux-gnu`
   - `x86_64-unknown-linux-musl`
-- macOS/iOS
+- macOS/iOS/tvOS/watchOS/visionOS
   - `aarch64-apple-darwin`
   - `aarch64-apple-ios`
   - `x86_64-apple-darwin`

--- a/doc/platforms.md
+++ b/doc/platforms.md
@@ -33,8 +33,8 @@ The BSDs basically **only** have the Termios2 API, but they call it Termios. It 
 
  * https://man.openbsd.org/tty.4
 
-## macOS and iOS
+## Darwin
 
-While macOS and iOS have the heritage of a BSD, their support is slightly different. In theory, they support arbitrary baud rates in their Termios API much like the BSDs, but in practice this doesn't work with many hardware devices, as it's dependent on driver support. Instead, Apple added the `IOSSIOSPEED` ioctl in Mac OS X 10.4, which can set the baud rate to an arbitrary value. As the oldest macOS version supported by Rust is 10.7, it's available on all Mac platforms.
+While macOS, iOS, and similar Apple platforms have the heritage of a BSD, their support is slightly different. In theory, they support arbitrary baud rates in their Termios API much like the BSDs, but in practice this doesn't work with many hardware devices, as it's dependent on driver support. Instead, Apple added the `IOSSIOSPEED` ioctl in Mac OS X 10.4, which can set the baud rate to an arbitrary value. As the oldest macOS version supported by Rust is 10.7, it's available on all Mac platforms.
 
 This API requires the port to be set into raw mode with `cfmakeraw`, and must be done after every call to `tcsetattr`, as that will reset the baud rate. Additionally, there is no way to retrieve the actual baud rate from the OS. This is therefore the clunkiest API of any platform.

--- a/src/posix/enumerate.rs
+++ b/src/posix/enumerate.rs
@@ -8,7 +8,7 @@ cfg_if! {
 
 cfg_if! {
     if #[cfg(target_vendor = "apple")] {
-        use core::ffi::{c_char, c_int, c_uint, CStr};
+        use core::ffi::{c_int, c_uint, CStr};
         use core::mem::MaybeUninit;
 
         use objc2_core_foundation::{
@@ -325,7 +325,7 @@ fn get_parent_device_by_type(
 ) -> Option<io_registry_entry_t> {
     let mut device = device;
     loop {
-        let mut class_name = MaybeUninit::<[c_char; 128]>::uninit();
+        let mut class_name = MaybeUninit::uninit();
         unsafe { IOObjectGetClass(device, class_name.as_mut_ptr()) };
         let class_name = unsafe { class_name.assume_init() };
         let name = unsafe { CStr::from_ptr(&class_name[0]) };

--- a/src/posix/enumerate.rs
+++ b/src/posix/enumerate.rs
@@ -392,6 +392,8 @@ fn get_int_property(device_type: io_registry_entry_t, property: &str) -> Result<
 fn get_string_property(device_type: io_registry_entry_t, property: &str) -> Result<String> {
     let cf_property = CFString::from_str(property);
 
+    // SAFETY: We are calling `IORegistryEntryCreateCFProperty` with valid arguments and have
+    // allocated `cf_property` right above.
     let cf_type = unsafe {
         IORegistryEntryCreateCFProperty(device_type, Some(&cf_property), kCFAllocatorDefault, 0)
     }

--- a/src/posix/enumerate.rs
+++ b/src/posix/enumerate.rs
@@ -8,20 +8,21 @@ cfg_if! {
 
 cfg_if! {
     if #[cfg(target_vendor = "apple")] {
-        use core_foundation::base::CFType;
-        use core_foundation::base::TCFType;
-        use core_foundation::dictionary::CFDictionary;
-        use core_foundation::dictionary::CFMutableDictionary;
-        use core_foundation::number::CFNumber;
-        use core_foundation::string::CFString;
-        use core_foundation_sys::base::{kCFAllocatorDefault, CFRetain};
-        use io_kit_sys::*;
-        use io_kit_sys::keys::*;
-        use io_kit_sys::serial::keys::*;
-        use io_kit_sys::types::*;
-        use io_kit_sys::usb::lib::*;
-        use core::ffi::{c_char, c_int, c_uint, c_void, CStr};
+        use core::ffi::{c_char, c_int, c_uint, CStr};
         use core::mem::MaybeUninit;
+
+        use objc2_core_foundation::{
+            kCFAllocatorDefault, CFMutableDictionary, CFNumber, CFRetained, CFString, CFType,
+        };
+        #[allow(deprecated)]
+        use objc2_io_kit::{kIOMasterPortDefault, IOMasterPort};
+        use objc2_io_kit::{
+            io_object_t, io_registry_entry_t, kIOServiceClass, kIOUSBDeviceClassName,
+            kIOUSBHostInterfaceClassName, IOIteratorNext, IOObjectGetClass, IOObjectRelease,
+            IORegistryEntryCreateCFProperties, IORegistryEntryCreateCFProperty,
+            IORegistryEntryGetParentEntry, IOServiceGetMatchingServices, IOServiceMatching,
+            kIOSerialBSDServiceValue, kIOSerialBSDTypeKey, kIOSerialBSDAllTypes,
+        };
 
         // NOTE: Do not use `mach` nor `mach2` crates, they're unmaintained,
         // and don't work on tvOS/watchOS/visionOS.
@@ -320,13 +321,12 @@ fn parse_modalias(moda: &str) -> Option<UsbPortInfo> {
 #[cfg(target_vendor = "apple")]
 fn get_parent_device_by_type(
     device: io_object_t,
-    parent_type: *const c_char,
+    parent_type: &CStr,
 ) -> Option<io_registry_entry_t> {
-    let parent_type = unsafe { CStr::from_ptr(parent_type) };
     let mut device = device;
     loop {
         let mut class_name = MaybeUninit::<[c_char; 128]>::uninit();
-        unsafe { IOObjectGetClass(device, class_name.as_mut_ptr() as *mut c_char) };
+        unsafe { IOObjectGetClass(device, class_name.as_mut_ptr()) };
         let class_name = unsafe { class_name.assume_init() };
         let name = unsafe { CStr::from_ptr(&class_name[0]) };
         if name == parent_type {
@@ -334,8 +334,11 @@ fn get_parent_device_by_type(
         }
         let mut parent = MaybeUninit::uninit();
         if unsafe {
-            IORegistryEntryGetParentEntry(device, kIOServiceClass, parent.as_mut_ptr())
-                != KERN_SUCCESS
+            IORegistryEntryGetParentEntry(
+                device,
+                kIOServiceClass.as_ptr() as _,
+                parent.as_mut_ptr(),
+            ) != KERN_SUCCESS
         } {
             return None;
         }
@@ -347,24 +350,17 @@ fn get_parent_device_by_type(
 #[allow(non_upper_case_globals)]
 /// Returns a specific property of the given device as an integer.
 fn get_int_property(device_type: io_registry_entry_t, property: &str) -> Result<u32> {
-    let cf_property = CFString::new(property);
+    let cf_property = CFString::from_str(property);
 
-    let cf_type_ref = unsafe {
-        IORegistryEntryCreateCFProperty(
-            device_type,
-            cf_property.as_concrete_TypeRef(),
-            kCFAllocatorDefault,
-            0,
-        )
-    };
-    if cf_type_ref.is_null() {
-        return Err(Error::new(ErrorKind::Unknown, "Failed to get property"));
+    let cf_type = unsafe {
+        IORegistryEntryCreateCFProperty(device_type, Some(&cf_property), kCFAllocatorDefault, 0)
     }
+    .ok_or_else(|| Error::new(ErrorKind::Unknown, "Failed to get property"))?;
 
-    let cf_type = unsafe { CFType::wrap_under_create_rule(cf_type_ref) };
     cf_type
         .downcast::<CFNumber>()
-        .and_then(|n| n.to_i64())
+        .ok()
+        .and_then(|n| n.as_i64())
         .map(|n| n as u32)
         .ok_or(Error::new(
             ErrorKind::Unknown,
@@ -375,23 +371,16 @@ fn get_int_property(device_type: io_registry_entry_t, property: &str) -> Result<
 #[cfg(target_vendor = "apple")]
 /// Returns a specific property of the given device as a string.
 fn get_string_property(device_type: io_registry_entry_t, property: &str) -> Result<String> {
-    let cf_property = CFString::new(property);
+    let cf_property = CFString::from_str(property);
 
-    let cf_type_ref = unsafe {
-        IORegistryEntryCreateCFProperty(
-            device_type,
-            cf_property.as_concrete_TypeRef(),
-            kCFAllocatorDefault,
-            0,
-        )
-    };
-    if cf_type_ref.is_null() {
-        return Err(Error::new(ErrorKind::Unknown, "Failed to get property"));
+    let cf_type = unsafe {
+        IORegistryEntryCreateCFProperty(device_type, Some(&cf_property), kCFAllocatorDefault, 0)
     }
+    .ok_or_else(|| Error::new(ErrorKind::Unknown, "Failed to get property"))?;
 
-    let cf_type = unsafe { CFType::wrap_under_create_rule(cf_type_ref) };
     cf_type
         .downcast::<CFString>()
+        .ok()
         .map(|s| s.to_string())
         .ok_or(Error::new(ErrorKind::Unknown, "Failed to get string value"))
 }
@@ -430,8 +419,9 @@ impl crate::Location {
 /// Determine the serial port type based on the service object (like that returned by
 /// `IOIteratorNext`). Specific properties are extracted for USB devices.
 fn port_type(service: io_object_t) -> SerialPortType {
-    let bluetooth_device_class_name = b"IOBluetoothSerialClient\0".as_ptr() as *const c_char;
-    let usb_device_class_name = b"IOUSBHostInterface\0".as_ptr() as *const c_char;
+    let bluetooth_device_class_name =
+        CStr::from_bytes_with_nul(b"IOBluetoothSerialClient\0").unwrap();
+    let usb_device_class_name = kIOUSBHostInterfaceClassName;
     let legacy_usb_device_class_name = kIOUSBDeviceClassName;
 
     let maybe_usb_device = get_parent_device_by_type(service, usb_device_class_name)
@@ -467,29 +457,24 @@ cfg_if! {
     if #[cfg(target_vendor = "apple")] {
         /// Scans the system for serial ports and returns a list of them.
         /// The `SerialPortInfo` struct contains the name of the port which can be used for opening it.
+        #[allow(deprecated)]
         pub fn available_ports() -> Result<Vec<SerialPortInfo>> {
             let mut vec = Vec::new();
             unsafe {
                 // Create a dictionary for specifying the search terms against the IOService
-                let classes_to_match = IOServiceMatching(kIOSerialBSDServiceValue);
-                if classes_to_match.is_null() {
-                    return Err(Error::new(
-                        ErrorKind::Unknown,
-                        "IOServiceMatching returned a NULL dictionary.",
-                    ));
-                }
-                let mut classes_to_match = CFMutableDictionary::wrap_under_create_rule(classes_to_match);
+                let classes_to_match = IOServiceMatching(kIOSerialBSDServiceValue.as_ptr())
+                .ok_or_else(|| Error::new(ErrorKind::Unknown, "IOServiceMatching returned a NULL dictionary."))?;
+                let classes_to_match = classes_to_match.cast_unchecked::<CFString, CFType>();
 
                 // Populate the search dictionary with a single key/value pair indicating that we're
                 // searching for serial devices matching the RS232 device type.
-                let search_key = CStr::from_ptr(kIOSerialBSDTypeKey);
-                let search_key = CFString::from_static_string(search_key.to_str().map_err(|_| Error::new(ErrorKind::Unknown, "Failed to convert search key string"))?);
-                let search_value = CStr::from_ptr(kIOSerialBSDAllTypes);
-                let search_value = CFString::from_static_string(search_value.to_str().map_err(|_| Error::new(ErrorKind::Unknown, "Failed to convert search key string"))?);
-                classes_to_match.set(search_key, search_value);
+                let search_key = CFString::from_static_str(kIOSerialBSDTypeKey.to_str().map_err(|_| Error::new(ErrorKind::Unknown, "Failed to convert search key string"))?);
+                let search_value = CFString::from_static_str(kIOSerialBSDAllTypes.to_str().map_err(|_| Error::new(ErrorKind::Unknown, "Failed to convert search key string"))?);
+                classes_to_match.set(&search_key, &search_value);
 
                 // Get an interface to IOKit
                 let mut master_port: mach_port_t = MACH_PORT_NULL;
+                #[allow(deprecated)]
                 let mut kern_result = IOMasterPort(MACH_PORT_NULL, &mut master_port);
                 if kern_result != KERN_SUCCESS {
                     return Err(Error::new(
@@ -498,17 +483,11 @@ cfg_if! {
                     ));
                 }
 
-                // Run the search. IOServiceGetMatchingServices consumes one reference count of
-                // classes_to_match, so explicitly retain.
-                //
-                // TODO: We could also just mem::forget classes_to_match like in
-                // TCFType::into_CFType. Is there a special reason that there is no
-                // TCFType::into_concrete_TypeRef()?
-                CFRetain(classes_to_match.as_CFTypeRef());
+                // Run the search.
                 let mut matching_services = MaybeUninit::uninit();
                 kern_result = IOServiceGetMatchingServices(
                     kIOMasterPortDefault,
-                    classes_to_match.as_concrete_TypeRef(),
+                    Some(classes_to_match.as_opaque().into()),
                     matching_services.as_mut_ptr(),
                 );
                 if kern_result != KERN_SUCCESS {
@@ -546,15 +525,15 @@ cfg_if! {
                         // properties dict has been allocated and we as the caller are in charge of
                         // releasing it.
                         let props = props.assume_init();
-                        let props: CFDictionary<CFString, *const c_void> = CFDictionary::wrap_under_create_rule(props);
+                        let props: CFRetained<CFMutableDictionary> = CFRetained::from_raw(core::ptr::NonNull::new(props).unwrap());
+                        let props = props.cast_unchecked::<CFString, CFType>();
 
                         for key in ["IOCalloutDevice", "IODialinDevice"].iter() {
-                            let cf_key = CFString::new(key);
+                            let cf_key = CFString::from_str(key);
 
-                            if let Some(cf_ref) = props.find(cf_key) {
-                                let cf_type = CFType::wrap_under_get_rule(*cf_ref);
+                            if let Some(cf_type) = props.get(&cf_key) {
                                 match cf_type
-                                     .downcast::<CFString>()
+                                     .downcast_ref::<CFString>()
                                      .map(|s| s.to_string())
                                 {
                                     Some(path) => {

--- a/src/posix/enumerate.rs
+++ b/src/posix/enumerate.rs
@@ -478,7 +478,6 @@ cfg_if! {
     if #[cfg(target_vendor = "apple")] {
         /// Scans the system for serial ports and returns a list of them.
         /// The `SerialPortInfo` struct contains the name of the port which can be used for opening it.
-        #[allow(deprecated)]
         pub fn available_ports() -> Result<Vec<SerialPortInfo>> {
             let mut vec = Vec::new();
             unsafe {
@@ -496,7 +495,7 @@ cfg_if! {
                 // Get an interface to IOKit
                 let mut master_port: mach_port_t = MACH_PORT_NULL;
                 #[allow(deprecated)]
-                let mut kern_result = IOMasterPort(MACH_PORT_NULL, &mut master_port);
+                let kern_result = IOMasterPort(MACH_PORT_NULL, &mut master_port);
                 if kern_result != KERN_SUCCESS {
                     return Err(Error::new(
                         ErrorKind::Unknown,
@@ -506,7 +505,8 @@ cfg_if! {
 
                 // Run the search.
                 let mut matching_services = MaybeUninit::uninit();
-                kern_result = IOServiceGetMatchingServices(
+                #[allow(deprecated)]
+                let kern_result = IOServiceGetMatchingServices(
                     kIOMasterPortDefault,
                     Some(classes_to_match.as_opaque().into()),
                     matching_services.as_mut_ptr(),

--- a/src/posix/enumerate.rs
+++ b/src/posix/enumerate.rs
@@ -20,9 +20,20 @@ cfg_if! {
         use io_kit_sys::serial::keys::*;
         use io_kit_sys::types::*;
         use io_kit_sys::usb::lib::*;
-        use nix::libc::{c_char, c_void};
-        use std::ffi::CStr;
-        use std::mem::MaybeUninit;
+        use core::ffi::{c_char, c_int, c_uint, c_void, CStr};
+        use core::mem::MaybeUninit;
+
+        // NOTE: Do not use `mach` nor `mach2` crates, they're unmaintained,
+        // and don't work on tvOS/watchOS/visionOS.
+        //
+        // Instead, define the types ourselves, we use sufficiently little
+        // that this is not a very hard task.
+        #[allow(non_camel_case_types)]
+        type kern_return_t = c_int;
+        #[allow(non_camel_case_types)]
+        type mach_port_t = c_uint;
+        const KERN_SUCCESS: kern_return_t = 0;
+        const MACH_PORT_NULL: mach_port_t = 0;
     }
 }
 
@@ -312,7 +323,6 @@ fn get_parent_device_by_type(
     parent_type: *const c_char,
 ) -> Option<io_registry_entry_t> {
     let parent_type = unsafe { CStr::from_ptr(parent_type) };
-    use mach2::kern_return::KERN_SUCCESS;
     let mut device = device;
     loop {
         let mut class_name = MaybeUninit::<[c_char; 128]>::uninit();
@@ -458,9 +468,6 @@ cfg_if! {
         /// Scans the system for serial ports and returns a list of them.
         /// The `SerialPortInfo` struct contains the name of the port which can be used for opening it.
         pub fn available_ports() -> Result<Vec<SerialPortInfo>> {
-            use mach2::kern_return::KERN_SUCCESS;
-            use mach2::port::{mach_port_t, MACH_PORT_NULL};
-
             let mut vec = Vec::new();
             unsafe {
                 // Create a dictionary for specifying the search terms against the IOService

--- a/src/posix/enumerate.rs
+++ b/src/posix/enumerate.rs
@@ -17,7 +17,7 @@ cfg_if! {
         #[allow(deprecated)]
         use objc2_io_kit::{kIOMasterPortDefault, IOMasterPort};
         use objc2_io_kit::{
-            io_object_t, io_registry_entry_t, kIOServiceClass, kIOUSBDeviceClassName,
+            io_object_t, io_registry_entry_t, kIOServicePlane, kIOUSBDeviceClassName,
             kIOUSBHostInterfaceClassName, IOIteratorNext, IOObjectGetClass, IOObjectRelease,
             IORegistryEntryCreateCFProperties, IORegistryEntryCreateCFProperty,
             IORegistryEntryGetParentEntry, IOServiceGetMatchingServices, IOServiceMatching,
@@ -336,7 +336,7 @@ fn get_parent_device_by_type(
         if unsafe {
             IORegistryEntryGetParentEntry(
                 device,
-                kIOServiceClass.as_ptr() as _,
+                kIOServicePlane.as_ptr() as _,
                 parent.as_mut_ptr(),
             ) != KERN_SUCCESS
         } {

--- a/src/posix/enumerate.rs
+++ b/src/posix/enumerate.rs
@@ -325,23 +325,36 @@ fn get_parent_device_by_type(
 ) -> Option<io_registry_entry_t> {
     let mut device = device;
     loop {
-        let mut class_name = MaybeUninit::uninit();
-        unsafe { IOObjectGetClass(device, class_name.as_mut_ptr()) };
+        let mut class_name = MaybeUninit::zeroed();
+        // SAFETY: `device` is supposed to be valid `io_object_t` and `class_name` points to a
+        // zero-initialzed buffer of the required size.
+        if KERN_SUCCESS != unsafe { IOObjectGetClass(device, class_name.as_mut_ptr()) } {
+            return None;
+        }
+        // SAFETY: We successfully called `IOObjectGetClass` and can now assume that `class_name`
+        // contains either completely zeroed data ot a valid C string.
         let class_name = unsafe { class_name.assume_init() };
-        let name = unsafe { CStr::from_ptr(&class_name[0]) };
+
+        // SAFETY: `class_name` contains a valid C sting (which might be empty).
+        let name = unsafe { CStr::from_ptr(class_name.as_ptr()) };
         if name == parent_type {
             return Some(device);
         }
+
         let mut parent = MaybeUninit::uninit();
-        if unsafe {
-            IORegistryEntryGetParentEntry(
-                device,
-                kIOServicePlane.as_ptr() as _,
-                parent.as_mut_ptr(),
-            ) != KERN_SUCCESS
-        } {
+        if KERN_SUCCESS
+            != unsafe {
+                IORegistryEntryGetParentEntry(
+                    device,
+                    kIOServicePlane.as_ptr() as _,
+                    parent.as_mut_ptr(),
+                )
+            }
+        {
             return None;
         }
+        // SAFETY: We checked right above that we successfully called
+        // `IORegistryEntryGetParentEntry` and can assume a valid `io_registry_entry_t` in `parent`.
         device = unsafe { parent.assume_init() };
     }
 }

--- a/src/posix/enumerate.rs
+++ b/src/posix/enumerate.rs
@@ -7,7 +7,7 @@ cfg_if! {
 }
 
 cfg_if! {
-    if #[cfg(any(target_os = "ios", target_os = "macos"))] {
+    if #[cfg(target_vendor = "apple")] {
         use core_foundation::base::CFType;
         use core_foundation::base::TCFType;
         use core_foundation::dictionary::CFDictionary;
@@ -26,22 +26,16 @@ cfg_if! {
     }
 }
 
-#[cfg(any(
-    target_os = "freebsd",
-    target_os = "ios",
-    target_os = "linux",
-    target_os = "macos"
-))]
+#[cfg(any(target_os = "freebsd", target_os = "linux", target_vendor = "apple"))]
 use crate::SerialPortType;
-#[cfg(any(target_os = "ios", target_os = "linux", target_os = "macos"))]
+#[cfg(any(target_os = "linux", target_vendor = "apple"))]
 use crate::UsbPortInfo;
 #[cfg(any(
     target_os = "android",
-    target_os = "ios",
     all(target_os = "linux", not(target_env = "musl"), feature = "libudev"),
-    target_os = "macos",
     target_os = "netbsd",
     target_os = "openbsd",
+    target_vendor = "apple",
 ))]
 use crate::{Error, ErrorKind};
 use crate::{Result, SerialPortInfo};
@@ -312,7 +306,7 @@ fn parse_modalias(moda: &str) -> Option<UsbPortInfo> {
     })
 }
 
-#[cfg(any(target_os = "ios", target_os = "macos"))]
+#[cfg(target_vendor = "apple")]
 fn get_parent_device_by_type(
     device: io_object_t,
     parent_type: *const c_char,
@@ -339,7 +333,7 @@ fn get_parent_device_by_type(
     }
 }
 
-#[cfg(any(target_os = "ios", target_os = "macos"))]
+#[cfg(target_vendor = "apple")]
 #[allow(non_upper_case_globals)]
 /// Returns a specific property of the given device as an integer.
 fn get_int_property(device_type: io_registry_entry_t, property: &str) -> Result<u32> {
@@ -368,7 +362,7 @@ fn get_int_property(device_type: io_registry_entry_t, property: &str) -> Result<
         ))
 }
 
-#[cfg(any(target_os = "ios", target_os = "macos"))]
+#[cfg(target_vendor = "apple")]
 /// Returns a specific property of the given device as a string.
 fn get_string_property(device_type: io_registry_entry_t, property: &str) -> Result<String> {
     let cf_property = CFString::new(property);
@@ -392,7 +386,6 @@ fn get_string_property(device_type: io_registry_entry_t, property: &str) -> Resu
         .ok_or(Error::new(ErrorKind::Unknown, "Failed to get string value"))
 }
 
-#[cfg(any(target_os = "ios", target_os = "macos"))]
 impl crate::Location {
     /// Creates a `Location` from a location ID from Apple's I/O registry.
     ///
@@ -423,7 +416,7 @@ impl crate::Location {
     }
 }
 
-#[cfg(any(target_os = "ios", target_os = "macos"))]
+#[cfg(target_vendor = "apple")]
 /// Determine the serial port type based on the service object (like that returned by
 /// `IOIteratorNext`). Specific properties are extracted for USB devices.
 fn port_type(service: io_object_t) -> SerialPortType {
@@ -461,7 +454,7 @@ fn port_type(service: io_object_t) -> SerialPortType {
 }
 
 cfg_if! {
-    if #[cfg(any(target_os = "ios", target_os = "macos"))] {
+    if #[cfg(target_vendor = "apple")] {
         /// Scans the system for serial ports and returns a list of them.
         /// The `SerialPortInfo` struct contains the name of the port which can be used for opening it.
         pub fn available_ports() -> Result<Vec<SerialPortInfo>> {

--- a/src/posix/enumerate.rs
+++ b/src/posix/enumerate.rs
@@ -365,6 +365,8 @@ fn get_parent_device_by_type(
 fn get_int_property(device_type: io_registry_entry_t, property: &str) -> Result<u32> {
     let cf_property = CFString::from_str(property);
 
+    // SAFETY: We are calling `IORegistryEntryCreateCFProperty` with valid arguments and allocated
+    // `cf_property` right above.
     let cf_type = unsafe {
         IORegistryEntryCreateCFProperty(device_type, Some(&cf_property), kCFAllocatorDefault, 0)
     }
@@ -374,11 +376,15 @@ fn get_int_property(device_type: io_registry_entry_t, property: &str) -> Result<
         .downcast::<CFNumber>()
         .ok()
         .and_then(|n| n.as_i64())
-        .map(|n| n as u32)
-        .ok_or(Error::new(
-            ErrorKind::Unknown,
-            "Failed to get numerical value",
-        ))
+        .ok_or_else(|| Error::new(ErrorKind::Unknown, "Failed to get numerical value"))
+        .and_then(|n| {
+            n.try_into().map_err(|e| {
+                Error::new(
+                    ErrorKind::Unknown,
+                    format!("Failed to convert to u32 ({e})"),
+                )
+            })
+        })
 }
 
 #[cfg(target_vendor = "apple")]

--- a/src/posix/ioctl.rs
+++ b/src/posix/ioctl.rs
@@ -23,10 +23,9 @@ mod raw {
     #[cfg(any(
         target_os = "dragonfly",
         target_os = "freebsd",
-        target_os = "ios",
-        target_os = "macos",
         target_os = "netbsd",
-        target_os = "openbsd"
+        target_os = "openbsd",
+        target_vendor = "apple",
     ))]
     ioctl_read!(fionread, b'f', 127, libc::c_int);
 
@@ -37,10 +36,9 @@ mod raw {
     #[cfg(any(
         target_os = "dragonfly",
         target_os = "freebsd",
-        target_os = "ios",
-        target_os = "macos",
         target_os = "netbsd",
-        target_os = "openbsd"
+        target_os = "openbsd",
+        target_vendor = "apple"
     ))]
     ioctl_read!(tiocoutq, b't', 115, libc::c_int);
 
@@ -72,10 +70,10 @@ mod raw {
         0x2B,
         libc::termios2
     );
-    #[cfg(any(target_os = "ios", target_os = "macos"))]
+    #[cfg(target_vendor = "apple")]
     const IOSSIOSPEED: libc::c_ulong = 0x80045402;
     ioctl_write_ptr_bad!(
-        #[cfg(any(target_os = "ios", target_os = "macos"))]
+        #[cfg(target_vendor = "apple")]
         iossiospeed,
         IOSSIOSPEED,
         libc::speed_t
@@ -183,7 +181,7 @@ pub fn tcsets2(fd: RawFd, options: &libc::termios2) -> Result<()> {
         .map_err(|e| e.into())
 }
 
-#[cfg(any(target_os = "ios", target_os = "macos"))]
+#[cfg(target_vendor = "apple")]
 pub fn iossiospeed(fd: RawFd, baud_rate: &libc::speed_t) -> Result<()> {
     unsafe { raw::iossiospeed(fd, baud_rate) }
         .map(|_| ())

--- a/src/posix/termios.rs
+++ b/src/posix/termios.rs
@@ -10,8 +10,6 @@ cfg_if! {
     if #[cfg(any(
         target_os = "dragonfly",
         target_os = "freebsd",
-        target_os = "ios",
-        target_os = "macos",
         target_os = "netbsd",
         target_os = "openbsd",
         all(
@@ -20,7 +18,8 @@ cfg_if! {
                 target_arch = "powerpc",
                 target_arch = "powerpc64"
             )
-        )
+        ),
+        target_vendor = "apple",
     ))] {
         pub(crate) type Termios = libc::termios;
     } else if #[cfg(any(
@@ -40,7 +39,7 @@ cfg_if! {
 // calls in this lib to the IOSSIOSPEED ioctl. So whenever we get this struct, make sure to
 // reset the input & output baud rates to a safe default. This is accounted for by the
 // corresponding set_termios that is mac-specific and always calls IOSSIOSPEED.
-#[cfg(any(target_os = "ios", target_os = "macos",))]
+#[cfg(target_vendor = "apple")]
 pub(crate) fn get_termios(fd: RawFd) -> Result<Termios> {
     use std::mem::MaybeUninit;
 
@@ -83,7 +82,7 @@ pub(crate) fn get_termios(fd: RawFd) -> Result<Termios> {
     crate::posix::ioctl::tcgets2(fd)
 }
 
-#[cfg(any(target_os = "ios", target_os = "macos",))]
+#[cfg(target_vendor = "apple")]
 pub(crate) fn set_termios(fd: RawFd, termios: &libc::termios, baud_rate: u32) -> Result<()> {
     let res = unsafe { libc::tcsetattr(fd, libc::TCSANOW, termios) };
     nix::errno::Errno::result(res)?;

--- a/src/posix/tty.rs
+++ b/src/posix/tty.rs
@@ -71,7 +71,7 @@ pub struct TTYPort {
     timeout: Duration,
     exclusive: bool,
     port_name: Option<String>,
-    #[cfg(any(target_os = "ios", target_os = "macos"))]
+    #[cfg(target_vendor = "apple")]
     baud_rate: u32,
 }
 
@@ -150,7 +150,7 @@ impl TTYPort {
             ));
         };
 
-        #[cfg(any(target_os = "ios", target_os = "macos"))]
+        #[cfg(target_vendor = "apple")]
         if builder.baud_rate > 0 {
             Errno::result(unsafe { libc::tcflush(fd.as_raw_fd(), libc::TCIOFLUSH) })?;
         }
@@ -164,12 +164,12 @@ impl TTYPort {
         termios::set_flow_control(&mut termios, builder.flow_control);
         termios::set_data_bits(&mut termios, builder.data_bits);
         termios::set_stop_bits(&mut termios, builder.stop_bits);
-        #[cfg(not(any(target_os = "ios", target_os = "macos")))]
+        #[cfg(not(target_vendor = "apple"))]
         termios::set_baud_rate(&mut termios, builder.baud_rate)?;
-        #[cfg(any(target_os = "ios", target_os = "macos"))]
-        termios::set_termios(fd.as_raw_fd(), &termios, builder.baud_rate)?;
-        #[cfg(not(any(target_os = "ios", target_os = "macos")))]
+        #[cfg(not(target_vendor = "apple"))]
         termios::set_termios(fd.as_raw_fd(), &termios)?;
+        #[cfg(target_vendor = "apple")]
+        termios::set_termios(fd.as_raw_fd(), &termios, builder.baud_rate)?;
 
         // Return the final port object
         let mut port = TTYPort {
@@ -177,7 +177,7 @@ impl TTYPort {
             timeout: builder.timeout,
             exclusive: builder.exclusive,
             port_name: Some(builder.path.clone()),
-            #[cfg(any(target_os = "ios", target_os = "macos"))]
+            #[cfg(target_vendor = "apple")]
             baud_rate: builder.baud_rate,
         };
 
@@ -299,7 +299,7 @@ impl TTYPort {
         let ptty_name = nix::pty::ptsname_r(&master)?;
 
         // Open the slave port
-        #[cfg(any(target_os = "ios", target_os = "macos"))]
+        #[cfg(target_vendor = "apple")]
         let baud_rate = 9600;
 
         let slave_fd = nix::fcntl::open(
@@ -327,7 +327,7 @@ impl TTYPort {
             timeout: Duration::from_millis(100),
             exclusive: true,
             port_name: Some(ptty_name),
-            #[cfg(any(target_os = "ios", target_os = "macos"))]
+            #[cfg(target_vendor = "apple")]
             baud_rate,
         };
 
@@ -341,7 +341,7 @@ impl TTYPort {
             timeout: Duration::from_millis(100),
             exclusive: true,
             port_name: None,
-            #[cfg(any(target_os = "ios", target_os = "macos"))]
+            #[cfg(target_vendor = "apple")]
             baud_rate,
         };
 
@@ -384,7 +384,7 @@ impl TTYPort {
             exclusive: self.exclusive,
             port_name: self.port_name.clone(),
             timeout: self.timeout,
-            #[cfg(any(target_os = "ios", target_os = "macos"))]
+            #[cfg(target_vendor = "apple")]
             baud_rate: self.baud_rate,
         })
     }
@@ -403,7 +403,7 @@ impl IntoRawFd for TTYPort {
 }
 
 /// Get the baud speed for a port from its file descriptor
-#[cfg(any(target_os = "ios", target_os = "macos"))]
+#[cfg(target_vendor = "apple")]
 fn get_termios_speed(fd: RawFd) -> u32 {
     let mut termios = MaybeUninit::uninit();
     // TODO: Propagate error instead of panicking.
@@ -450,7 +450,7 @@ impl FromRawFd for TTYPort {
             // It is not trivial to get the file path corresponding to a file descriptor.
             // We'll punt on it and set it to `None` here.
             port_name: None,
-            #[cfg(any(target_os = "ios", target_os = "macos"))]
+            #[cfg(target_vendor = "apple")]
             baud_rate,
         }
     }
@@ -546,7 +546,7 @@ impl TTYPort {
     ///
     /// On some platforms this will be the actual device baud rate, which may differ from the
     /// desired baud rate.
-    #[cfg(any(target_os = "ios", target_os = "macos"))]
+    #[cfg(target_vendor = "apple")]
     pub(crate) fn baud_rate(&self) -> Result<u32> {
         Ok(self.baud_rate)
     }
@@ -678,7 +678,7 @@ impl TTYPort {
     }
 
     // Mac OS needs special logic for setting arbitrary baud rates.
-    #[cfg(any(target_os = "ios", target_os = "macos"))]
+    #[cfg(target_vendor = "apple")]
     pub(crate) fn set_baud_rate(&mut self, baud_rate: u32) -> Result<()> {
         ioctl::iossiospeed(self.fd.as_raw_fd(), &(baud_rate as libc::speed_t))?;
         self.baud_rate = baud_rate;
@@ -688,36 +688,36 @@ impl TTYPort {
     pub(crate) fn set_flow_control(&mut self, flow_control: FlowControl) -> Result<()> {
         let mut termios = termios::get_termios(self.fd.as_raw_fd())?;
         termios::set_flow_control(&mut termios, flow_control);
-        #[cfg(any(target_os = "ios", target_os = "macos"))]
+        #[cfg(target_vendor = "apple")]
         return termios::set_termios(self.fd.as_raw_fd(), &termios, self.baud_rate);
-        #[cfg(not(any(target_os = "ios", target_os = "macos")))]
+        #[cfg(not(target_vendor = "apple"))]
         return termios::set_termios(self.fd.as_raw_fd(), &termios);
     }
 
     pub(crate) fn set_parity(&mut self, parity: Parity) -> Result<()> {
         let mut termios = termios::get_termios(self.fd.as_raw_fd())?;
         termios::set_parity(&mut termios, parity);
-        #[cfg(any(target_os = "ios", target_os = "macos"))]
+        #[cfg(target_vendor = "apple")]
         return termios::set_termios(self.fd.as_raw_fd(), &termios, self.baud_rate);
-        #[cfg(not(any(target_os = "ios", target_os = "macos")))]
+        #[cfg(not(target_vendor = "apple"))]
         return termios::set_termios(self.fd.as_raw_fd(), &termios);
     }
 
     pub(crate) fn set_data_bits(&mut self, data_bits: DataBits) -> Result<()> {
         let mut termios = termios::get_termios(self.fd.as_raw_fd())?;
         termios::set_data_bits(&mut termios, data_bits);
-        #[cfg(any(target_os = "ios", target_os = "macos"))]
+        #[cfg(target_vendor = "apple")]
         return termios::set_termios(self.fd.as_raw_fd(), &termios, self.baud_rate);
-        #[cfg(not(any(target_os = "ios", target_os = "macos")))]
+        #[cfg(not(target_vendor = "apple"))]
         return termios::set_termios(self.fd.as_raw_fd(), &termios);
     }
 
     pub(crate) fn set_stop_bits(&mut self, stop_bits: StopBits) -> Result<()> {
         let mut termios = termios::get_termios(self.fd.as_raw_fd())?;
         termios::set_stop_bits(&mut termios, stop_bits);
-        #[cfg(any(target_os = "ios", target_os = "macos"))]
+        #[cfg(target_vendor = "apple")]
         return termios::set_termios(self.fd.as_raw_fd(), &termios, self.baud_rate);
-        #[cfg(not(any(target_os = "ios", target_os = "macos")))]
+        #[cfg(not(target_vendor = "apple"))]
         return termios::set_termios(self.fd.as_raw_fd(), &termios);
     }
 

--- a/tests/test_tty.rs
+++ b/tests/test_tty.rs
@@ -91,7 +91,7 @@ fn test_ttyport_timeout() {
 }
 
 #[test]
-#[cfg(any(target_os = "ios", target_os = "macos"))]
+#[cfg(target_vendor = "apple")]
 fn test_osx_pty_pair() {
     // FIXME: Create a mutex across all tests for using `SerialPort::pair()` as it's not threadsafe
     let (mut master, mut slave) = SerialPort::pair().expect("Unable to create ptty pair");
@@ -110,7 +110,7 @@ fn test_osx_pty_pair() {
 // On Mac this should work (in fact used to in b77768a) but now fails. It's not functionality that
 // should be required, and the ptys work otherwise. So going to just disable this test instead.
 #[test]
-#[cfg_attr(any(target_os = "ios", target_os = "macos"), ignore)]
+#[cfg_attr(target_vendor = "apple", ignore)]
 fn test_ttyport_set_standard_baud() {
     // FIXME: Create a mutex across all tests for using `SerialPort::pair()` as it's not threadsafe
 
@@ -125,18 +125,16 @@ fn test_ttyport_set_standard_baud() {
     assert_eq!(slave.baud_rate().unwrap(), 115_200);
 }
 
-// On mac this fails because you can't set nonstandard baud rates for these virtual ports
 #[test]
 #[cfg_attr(
     any(
-        target_os = "ios",
         all(
             target_os = "linux",
             any(target_arch = "powerpc", target_arch = "powerpc64")
         ),
-        target_os = "macos"
+        target_vendor = "apple",
     ),
-    ignore
+    ignore = "target does not support non-standard baud rates"
 )]
 fn test_ttyport_set_nonstandard_baud() {
     // FIXME: Create a mutex across all tests for using `SerialPort::pair()` as it's not threadsafe


### PR DESCRIPTION
Use [`objc2-io-kit`](https://docs.rs/objc2-io-kit/) and [`objc2-core-foundation`](https://docs.rs/objc2-core-foundation/) instead of [`io-kit-sys`](https://github.com/jtakakura/io-kit-rs) and [`core-foundation`](https://docs.rs/core-foundation/).

These are part of [the `objc2` project](https://github.com/madsmtm/objc2) which I maintain, which provides auto-generated bindings for Apple's APIs. This allows us to be much more confident that the bindings are correct, handles memory management like `CFRetain`/`CFRelease` automatically, allows us to do cool things like embedding documentation from the headers.

Note also that `core-foundation` has been soft-deprecated in favour of `objc2-core-foundation`, see https://github.com/servo/core-foundation-rs/issues/729, so it makes sense to start this migration.

This builds upon https://github.com/serialport/serialport-rs/pull/260, so that should probably be merged first. This change also requires an MSRV bump to 1.71 because these crates use `extern "C-unwind"`, so this should probably be put in the `v5.0.0` milestone IIUC, see also https://github.com/serialport/serialport-rs/issues/231.