### PR TITLE
Fix gerenating documentation at docs.rs and release 4.8.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,6 +42,25 @@ jobs:
         run: cargo clippy --all-targets --all-features
 
   # --------------------------------------------------------------------------
+  # Rustdoc
+
+  doc:
+    name: documentation
+    runs-on: ubuntu-latest
+    env:
+      RUSTDOCFLAGS: -Dwarnings
+    steps:
+      - name: documentation | install dependencies
+        run: |
+          sudo sed -i 's/azure.archive.ubuntu.com/archive.ubuntu.com/' /etc/apt/sources.list
+          sudo apt-get -qq update
+          sudo apt install -qq -y libudev-dev
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/install@cargo-docs-rs
+      - run: cargo docs-rs
+
+  # --------------------------------------------------------------------------
   # Link checks
 
   links:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ project adheres to [Semantic Versioning](https://semver.org/).
 ### Fixed
 ### Removed
 
+
+## [4.8.1] - 2025-10-07i
+
+### Fixed
+
+* Generating documentation on docs.rs.
+  [#299](https://github.com/serialport/serialport-rs/pull/299)
+
+
 ## [4.8.0] - 2025-10-06
 
 ### Added
@@ -556,7 +565,8 @@ Unreleased, happened due to a user error using `cargo-release`.
 * Initial release.
 
 
-[Unreleased]: https://github.com/serialport/serialport-rs/compare/v4.8.0...HEAD
+[Unreleased]: https://github.com/serialport/serialport-rs/compare/v4.8.1...HEAD
+[4.8.1]: https://github.com/serialport/serialport-rs/compare/v4.8.0...v4.8.1
 [4.8.0]: https://github.com/serialport/serialport-rs/compare/v4.7.3...v4.8.0
 [4.7.3]: https://github.com/serialport/serialport-rs/compare/v4.7.2...v4.7.3
 [4.7.2]: https://github.com/serialport/serialport-rs/compare/v4.7.1...v4.7.2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serialport"
-version = "4.8.1-alpha.0"
+version = "4.8.1"
 authors = [
     "Bryant Mairs <bryant@mai.rs>",
     "Jesse Braham <jesse@beta7.io>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serialport"
-version = "4.8.1"
+version = "4.8.2-alpha.0"
 authors = [
     "Bryant Mairs <bryant@mai.rs>",
     "Jesse Braham <jesse@beta7.io>",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,8 +27,8 @@
 // https://doc.rust-lang.org/rustdoc/unstable-features.html?highlight=doc(cfg#doccfg-recording-what-platforms-or-features-are-required-for-code-to-be-present
 // and
 // https://doc.rust-lang.org/rustdoc/unstable-features.html#doc_auto_cfg-automatically-generate-doccfg
-// for details.
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+// with its latest update https://github.com/rust-lang/rust/pull/138907 for details.
+#![cfg_attr(docsrs, feature(doc_cfg))]
 // Don't worry about needing to `unwrap()` or otherwise handle some results in
 // doc tests.
 #![doc(test(attr(allow(unused_must_use))))]


### PR DESCRIPTION
Generating the latest documentation on docs.rs failed with https://docs.rs/crate/serialport/4.8.0/builds/2566488. It looks like https://github.com/rust-lang/rust/pull/138907 landed there and we have to update our configuration for it.