### PR TITLE
Bump cargo-deny-action for CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -192,7 +192,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - uses: EmbarkStudios/cargo-deny-action@v1
+    - uses: EmbarkStudios/cargo-deny-action@v2
       with:
         command: check ${{ matrix.checks }}
 


### PR DESCRIPTION
The previously used version 1 failed parsing RUSTSEC-2024-0445.md:

    parse error: TOML parse error at line 8, column 8
      |
    8 | cvss = "CVSS:4.0/AV:N/AC:L/AT:P/PR:L/UI:N/VC:L/VI:L/VA:L/SC:N/SI:N/SA:N"