### PR TITLE
Unpin dependencies

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,6 +18,9 @@ on:
       toolchain:
         default: stable
         type: string
+      pin-incompatible-msrv-bump-dependencies:
+        default: false
+        type: boolean
       continue-on-error:
         default: false
         type: boolean
@@ -81,6 +84,23 @@ jobs:
 
       - name: Build | rust-cache
         uses: Swatinem/rust-cache@v2
+
+        # Pin some dependencies (for building with MSRV 1.59.0) just here in CI
+        # and not via Cargo.toml. The latter would enforce them to all users
+        # and not just the ones who want to build with an old Rust release. See
+        # issue https://github.com/serialport/serialport-rs/issues/324.
+        #
+        # The command line arguments below are for Cargo 1.59.0. The have
+        # changed with newer releases and need to be adjusted when bumbing our
+        # MSRV.
+      - name: Build | pin some dependencies for building with MSRV
+        if: ${{ inputs.pin-incompatible-msrv-bump-dependencies == true }}
+        run: |
+          cargo update --precise 0.10.0 --package core-foundation
+          cargo update --precise 0.2.163 --package libc
+          cargo update --precise 1.0.101 --package proc-macro2
+          cargo update --precise 1.0.40 --package quote
+          cargo update --precise 1.0.22 --package unicode-ident
 
       - name: Build | build library (default features)
         run: cargo build --target=${{ inputs.target }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,6 +87,7 @@ jobs:
       disable_tests: true
       target: aarch64-apple-darwin
       toolchain: "1.59.0"
+      pin-incompatible-msrv-bump-dependencies: true
 
   msrv-arm-linux-androideabi:
     uses: ./.github/workflows/build.yaml
@@ -95,6 +96,7 @@ jobs:
       disable_tests: true
       target: arm-linux-androideabi
       toolchain: "1.59.0"
+      pin-incompatible-msrv-bump-dependencies: true
 
   msrv-x86_64-unknown-freebsd:
     uses: ./.github/workflows/build.yaml
@@ -103,6 +105,7 @@ jobs:
       disable_tests: true
       target: x86_64-unknown-freebsd
       toolchain: "1.59.0"
+      pin-incompatible-msrv-bump-dependencies: true
 
   msrv-x86_64-unknown-linux-gnu:
     uses: ./.github/workflows/build.yaml
@@ -112,6 +115,7 @@ jobs:
       extra_packages: libudev-dev
       target: x86_64-unknown-linux-gnu
       toolchain: "1.59.0"
+      pin-incompatible-msrv-bump-dependencies: true
 
   msrv-x86_64-unknown-linux-musl:
     uses: ./.github/workflows/build.yaml
@@ -121,6 +125,7 @@ jobs:
       extra_packages: gcc-aarch64-linux-gnu
       target: aarch64-unknown-linux-musl
       toolchain: "1.59.0"
+      pin-incompatible-msrv-bump-dependencies: true
 
   msrv-x86_64-pc-windows-msvc:
     uses: ./.github/workflows/build.yaml
@@ -130,6 +135,7 @@ jobs:
       runs_on: windows-2025
       target: x86_64-pc-windows-msvc
       toolchain: "1.59.0"
+      pin-incompatible-msrv-bump-dependencies: true
 
   msrv-x86_64-unknown-netbsd:
     uses: ./.github/workflows/build.yaml
@@ -138,6 +144,7 @@ jobs:
       disable_tests: true
       target: x86_64-unknown-netbsd
       toolchain: "1.59.0"
+      pin-incompatible-msrv-bump-dependencies: true
 
   # --------------------------------------------------------------------------
   # Semantic Versioning

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,13 +27,21 @@ project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-
 * Always propagate errors out of termios getter/setter implementations.
 * Wrap slave port file descriptors in `TTYPort::pair` in a `Drop`-safe `OwnedFd` to avoid file descriptor leaks on early returns.
 * Enable arbitrary baud rates for Linux musl targets by using the `termios2`
   (`TCGETS2`/`TCSETS2` + `BOTHER`) path now that required `libc` symbols are
   available.
   [#316](https://github.com/serialport/serialport-rs/pull/316)
+* Unpin dependencies with MSRV incompatible Rust version bump. This caused
+  issues with dependency resolution for many users building with newer Rust
+  versions. See [Dependencies](README.md#dependencies) on how to pin them in
+  your project when building with older Rust versions.
+  [#324](https://github.com/serialport/serialport-rs/issues/324)
+  [#307](https://github.com/serialport/serialport-rs/issues/307)
+  [#304](https://github.com/serialport/serialport-rs/issues/304)
+  [#300](https://github.com/serialport/serialport-rs/issues/300)
+  [#231](https://github.com/serialport/serialport-rs/issues/231)
 
 ### Removed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,7 @@ libudev = { version = "0.3.0", optional = true }
 unescaper = "0.1.3"
 
 [target.'cfg(any(target_os = "ios", target_os = "macos"))'.dependencies]
-# TODO: Remove pinning this dependency when we are bumping our MSRV.
-core-foundation = "=0.10.0"
+core-foundation = "0.10.0"
 core-foundation-sys = "0.8.4"
 io-kit-sys = "0.4.0"
 mach2 = "0.4.1"
@@ -49,23 +48,11 @@ cfg-if = "1.0.0"
 scopeguard = "1.1"
 serde = { version = "1.0", features = ["derive"], optional = true }
 
-# TODO: Remove pinning this subdependency when we are bumping our MSRV.
-quote = ">=1, <=1.0.40"
-
 [dev-dependencies]
 assert_hex = "0.4.1"
 clap = { version = "3.1.6", features = ["derive"] }
 envconfig = "0.10.0"
-# TODES Remove pinning this subdependency (of clap) when we are bumping our
-# MSRV (libc raised its MSRV with a patch release 0.2.167 from 1.19.0 to
-# 1.63.0). Trick the resolver into picking a compatible release of libc by
-# adding it as a direct dependency meanwhile.
-libc = ">=0.2.0, <=0.2.163"
-# TODO: Remove pinning this subdependency of clap when we are bumping our MSRV.
-# (There has been an incompatible change with the MSRV of os_str_bytes with
-# 6.6.0) Until then we are tricking the dependency resolver into using a
-# compatible version by adding it as a direct dependency here.
-os_str_bytes = ">=6.0, <6.6.0"
+libc = "0.2.163"
 quickcheck = "1.0.3"
 quickcheck_macros = "1.0.0"
 rstest = { version = "0.12.0", default-features = false }

--- a/README.md
+++ b/README.md
@@ -132,6 +132,15 @@ feature):
 - Ubuntu: `sudo apt install libudev-dev`
 - Fedora: `sudo dnf install systemd-devel`
 
+We no longer pin dependencies of to versions compatible with our MSRV. This has
+created issues with failing dependency resolution for many users building with
+newer Rust versions (see issue
+[#324](https://github.com/serialport/serialport-rs/issues/324) for details). If
+you are building with and older Rust version down to our MSRV, you might want
+to pin such dependencies in your project to a working version with `cargo
+update --precise`. See [`build.yaml`](.github/workflows/build.yaml#L99) of an
+actual list of dependencies for our CI builds.
+
 # Platform Support
 
 Builds and some tests (not requiring actual hardware) for major targets are run


### PR DESCRIPTION
See #324 for details. To finally resolve all the issues from that.

I went for the `cargo update --precise` path as [cargo-minimal-versions](https://github.com/taiki-e/cargo-minimal-versions) wants to build the entire project and not just the library part with the given MSRV and we have examples requiring a higher Rust version.