### PR TITLE
Feature/split api 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,8 @@
 //! platform-specific port object which allows access to platform-specific functionality.
 
 #![allow(clippy::uninlined_format_args)]
+// Clippy's MSRV lint can disagree with macro-expanded code from dependencies (e.g. nix ioctl helpers) even when `cargo build` at the crate MSRV still succeeds. See CI `clippy` jobs.
+#![allow(clippy::incompatible_msrv)]
 #![deny(
     clippy::dbg_macro,
     missing_docs,
@@ -913,12 +915,12 @@ impl dyn SerialPort {
     /// This function returns an error if the serial port couldn't be cloned using `try_clone`.
     pub fn split(
         self: Box<Self>,
-    ) -> Result<(ReadHalf<Box<dyn SerialPort>>, WriteHalf<Box<dyn SerialPort>>)> {
+    ) -> Result<(
+        ReadHalf<Box<dyn SerialPort>>,
+        WriteHalf<Box<dyn SerialPort>>,
+    )> {
         let cloned = self.try_clone()?;
-        Ok((
-            ReadHalf { inner: self },
-            WriteHalf { inner: cloned },
-        ))
+        Ok((ReadHalf { inner: self }, WriteHalf { inner: cloned }))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -870,6 +870,58 @@ impl fmt::Debug for dyn SerialPort {
     }
 }
 
+/// A half of a `SerialPort` that can only be used for reading.
+///
+/// This is typically created by splitting a port into its read and write halves.
+#[derive(Debug)]
+pub struct ReadHalf<T> {
+    pub(crate) inner: T,
+}
+
+impl<T: io::Read> io::Read for ReadHalf<T> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.inner.read(buf)
+    }
+}
+
+/// A half of a `SerialPort` that can only be used for writing.
+///
+/// This is typically created by splitting a port into its read and write halves.
+#[derive(Debug)]
+pub struct WriteHalf<T> {
+    pub(crate) inner: T,
+}
+
+impl<T: io::Write> io::Write for WriteHalf<T> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.inner.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
+}
+
+impl dyn SerialPort {
+    /// Attempts to split the `SerialPort` into independent read and write halves.
+    ///
+    /// This allows you to write and read simultaneously from the same serial
+    /// connection on different threads without synchronization overhead.
+    ///
+    /// # Errors
+    ///
+    /// This function returns an error if the serial port couldn't be cloned using `try_clone`.
+    pub fn split(
+        self: Box<Self>,
+    ) -> Result<(ReadHalf<Box<dyn SerialPort>>, WriteHalf<Box<dyn SerialPort>>)> {
+        let cloned = self.try_clone()?;
+        Ok((
+            ReadHalf { inner: self },
+            WriteHalf { inner: cloned },
+        ))
+    }
+}
+
 /// Contains all possible USB information about a `SerialPort`
 #[derive(Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,6 +153,11 @@ pub enum DataBits {
     Eight,
 }
 
+/// Formats the value for a "developer and log locale".
+///
+/// This implementation provides a localized English string for developer logs and debugging,
+/// and is guaranteed to round-trip compatibly with `FromStr`. It is not intended
+/// for user-facing UI localization.
 impl fmt::Display for DataBits {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
@@ -160,6 +165,20 @@ impl fmt::Display for DataBits {
             DataBits::Six => write!(f, "Six"),
             DataBits::Seven => write!(f, "Seven"),
             DataBits::Eight => write!(f, "Eight"),
+        }
+    }
+}
+
+impl FromStr for DataBits {
+    type Err = ();
+
+    fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
+        match s {
+            "Five" | "five" | "5" => Ok(DataBits::Five),
+            "Six" | "six" | "6" => Ok(DataBits::Six),
+            "Seven" | "seven" | "7" => Ok(DataBits::Seven),
+            "Eight" | "eight" | "8" => Ok(DataBits::Eight),
+            _ => Err(()),
         }
     }
 }
@@ -211,12 +230,30 @@ pub enum Parity {
     Even,
 }
 
+/// Formats the value for a "developer and log locale".
+///
+/// This implementation provides a localized English string for developer logs and debugging,
+/// and is guaranteed to round-trip compatibly with `FromStr`. It is not intended
+/// for user-facing UI localization.
 impl fmt::Display for Parity {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             Parity::None => write!(f, "None"),
             Parity::Odd => write!(f, "Odd"),
             Parity::Even => write!(f, "Even"),
+        }
+    }
+}
+
+impl FromStr for Parity {
+    type Err = ();
+
+    fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
+        match s {
+            "None" | "none" | "N" | "n" => Ok(Parity::None),
+            "Odd" | "odd" | "O" | "o" => Ok(Parity::Odd),
+            "Even" | "even" | "E" | "e" => Ok(Parity::Even),
+            _ => Err(()),
         }
     }
 }
@@ -234,11 +271,28 @@ pub enum StopBits {
     Two,
 }
 
+/// Formats the value for a "developer and log locale".
+///
+/// This implementation provides a localized English string for developer logs and debugging,
+/// and is guaranteed to round-trip compatibly with `FromStr`. It is not intended
+/// for user-facing UI localization.
 impl fmt::Display for StopBits {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             StopBits::One => write!(f, "One"),
             StopBits::Two => write!(f, "Two"),
+        }
+    }
+}
+
+impl FromStr for StopBits {
+    type Err = ();
+
+    fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
+        match s {
+            "One" | "one" | "1" => Ok(StopBits::One),
+            "Two" | "two" | "2" => Ok(StopBits::Two),
+            _ => Err(()),
         }
     }
 }
@@ -278,6 +332,11 @@ pub enum FlowControl {
     Hardware,
 }
 
+/// Formats the value for a "developer and log locale".
+///
+/// This implementation provides a localized English string for developer logs and debugging,
+/// and is guaranteed to round-trip compatibly with `FromStr`. It is not intended
+/// for user-facing UI localization.
 impl fmt::Display for FlowControl {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {

--- a/src/posix/tty.rs
+++ b/src/posix/tty.rs
@@ -398,6 +398,22 @@ impl TTYPort {
             baud_rate: self.baud_rate,
         })
     }
+
+    /// Attempts to split the `TTYPort` into independent read and write halves.
+    ///
+    /// This allows you to write and read simultaneously from the same serial
+    /// connection on different threads without synchronization overhead.
+    ///
+    /// # Errors
+    ///
+    /// This function returns an error if the serial port couldn't be cloned using `try_clone_native`.
+    pub fn split(self) -> Result<(crate::ReadHalf<TTYPort>, crate::WriteHalf<TTYPort>)> {
+        let cloned = self.try_clone_native()?;
+        Ok((
+            crate::ReadHalf { inner: self },
+            crate::WriteHalf { inner: cloned },
+        ))
+    }
 }
 
 impl Drop for TTYPort {

--- a/src/tests/parse.rs
+++ b/src/tests/parse.rs
@@ -1,0 +1,114 @@
+use crate::{DataBits, FlowControl, Parity, StopBits};
+use std::str::FromStr;
+
+#[test]
+fn test_databits_from_str() {
+    assert_eq!(DataBits::from_str("Five"), Ok(DataBits::Five));
+    assert_eq!(DataBits::from_str("five"), Ok(DataBits::Five));
+    assert_eq!(DataBits::from_str("5"), Ok(DataBits::Five));
+
+    assert_eq!(DataBits::from_str("Six"), Ok(DataBits::Six));
+    assert_eq!(DataBits::from_str("six"), Ok(DataBits::Six));
+    assert_eq!(DataBits::from_str("6"), Ok(DataBits::Six));
+
+    assert_eq!(DataBits::from_str("Seven"), Ok(DataBits::Seven));
+    assert_eq!(DataBits::from_str("seven"), Ok(DataBits::Seven));
+    assert_eq!(DataBits::from_str("7"), Ok(DataBits::Seven));
+
+    assert_eq!(DataBits::from_str("Eight"), Ok(DataBits::Eight));
+    assert_eq!(DataBits::from_str("eight"), Ok(DataBits::Eight));
+    assert_eq!(DataBits::from_str("8"), Ok(DataBits::Eight));
+
+    assert_eq!(DataBits::from_str("Nine"), Err(()));
+    assert_eq!(DataBits::from_str(""), Err(()));
+
+    // Round-trip tests
+    for &variant in &[
+        DataBits::Five,
+        DataBits::Six,
+        DataBits::Seven,
+        DataBits::Eight,
+    ] {
+        assert_eq!(DataBits::from_str(&variant.to_string()), Ok(variant));
+        assert_eq!(DataBits::from_str(&format!("{:?}", variant)), Ok(variant));
+    }
+}
+
+#[test]
+fn test_parity_from_str() {
+    assert_eq!(Parity::from_str("None"), Ok(Parity::None));
+    assert_eq!(Parity::from_str("none"), Ok(Parity::None));
+    assert_eq!(Parity::from_str("N"), Ok(Parity::None));
+    assert_eq!(Parity::from_str("n"), Ok(Parity::None));
+
+    assert_eq!(Parity::from_str("Odd"), Ok(Parity::Odd));
+    assert_eq!(Parity::from_str("odd"), Ok(Parity::Odd));
+    assert_eq!(Parity::from_str("O"), Ok(Parity::Odd));
+    assert_eq!(Parity::from_str("o"), Ok(Parity::Odd));
+
+    assert_eq!(Parity::from_str("Even"), Ok(Parity::Even));
+    assert_eq!(Parity::from_str("even"), Ok(Parity::Even));
+    assert_eq!(Parity::from_str("E"), Ok(Parity::Even));
+    assert_eq!(Parity::from_str("e"), Ok(Parity::Even));
+
+    assert_eq!(Parity::from_str("Other"), Err(()));
+    assert_eq!(Parity::from_str(""), Err(()));
+
+    // Round-trip tests
+    for &variant in &[Parity::None, Parity::Odd, Parity::Even] {
+        assert_eq!(Parity::from_str(&variant.to_string()), Ok(variant));
+        assert_eq!(Parity::from_str(&format!("{:?}", variant)), Ok(variant));
+    }
+}
+
+#[test]
+fn test_stopbits_from_str() {
+    assert_eq!(StopBits::from_str("One"), Ok(StopBits::One));
+    assert_eq!(StopBits::from_str("one"), Ok(StopBits::One));
+    assert_eq!(StopBits::from_str("1"), Ok(StopBits::One));
+
+    assert_eq!(StopBits::from_str("Two"), Ok(StopBits::Two));
+    assert_eq!(StopBits::from_str("two"), Ok(StopBits::Two));
+    assert_eq!(StopBits::from_str("2"), Ok(StopBits::Two));
+
+    assert_eq!(StopBits::from_str("Three"), Err(()));
+    assert_eq!(StopBits::from_str(""), Err(()));
+
+    // Round-trip tests
+    for &variant in &[StopBits::One, StopBits::Two] {
+        assert_eq!(StopBits::from_str(&variant.to_string()), Ok(variant));
+        assert_eq!(StopBits::from_str(&format!("{:?}", variant)), Ok(variant));
+    }
+}
+
+#[test]
+fn test_flowcontrol_from_str() {
+    assert_eq!(FlowControl::from_str("None"), Ok(FlowControl::None));
+    assert_eq!(FlowControl::from_str("none"), Ok(FlowControl::None));
+    assert_eq!(FlowControl::from_str("n"), Ok(FlowControl::None));
+
+    assert_eq!(FlowControl::from_str("Software"), Ok(FlowControl::Software));
+    assert_eq!(FlowControl::from_str("software"), Ok(FlowControl::Software));
+    assert_eq!(FlowControl::from_str("SW"), Ok(FlowControl::Software));
+    assert_eq!(FlowControl::from_str("sw"), Ok(FlowControl::Software));
+    assert_eq!(FlowControl::from_str("s"), Ok(FlowControl::Software));
+
+    assert_eq!(FlowControl::from_str("Hardware"), Ok(FlowControl::Hardware));
+    assert_eq!(FlowControl::from_str("hardware"), Ok(FlowControl::Hardware));
+    assert_eq!(FlowControl::from_str("HW"), Ok(FlowControl::Hardware));
+    assert_eq!(FlowControl::from_str("hw"), Ok(FlowControl::Hardware));
+    assert_eq!(FlowControl::from_str("h"), Ok(FlowControl::Hardware));
+
+    assert_eq!(FlowControl::from_str("Other"), Err(()));
+    assert_eq!(FlowControl::from_str(""), Err(()));
+
+    // Round-trip tests
+    for &variant in &[
+        FlowControl::None,
+        FlowControl::Software,
+        FlowControl::Hardware,
+    ] {
+        assert_eq!(FlowControl::from_str(&variant.to_string()), Ok(variant));
+        assert_eq!(FlowControl::from_str(&format!("{:?}", variant)), Ok(variant));
+    }
+}

--- a/src/windows/com.rs
+++ b/src/windows/com.rs
@@ -139,6 +139,22 @@ impl COMPort {
         }
     }
 
+    /// Attempts to split the `COMPort` into independent read and write halves.
+    ///
+    /// This allows you to write and read simultaneously from the same serial
+    /// connection on different threads without synchronization overhead.
+    ///
+    /// # Errors
+    ///
+    /// This function returns an error if the serial port couldn't be cloned using `try_clone_native`.
+    pub fn split(self) -> Result<(crate::ReadHalf<COMPort>, crate::WriteHalf<COMPort>)> {
+        let cloned = self.try_clone_native()?;
+        Ok((
+            crate::ReadHalf { inner: self },
+            crate::WriteHalf { inner: cloned },
+        ))
+    }
+
     fn escape_comm_function(&mut self, function: u32) -> Result<()> {
         match unsafe { EscapeCommFunction(self.handle, function) } {
             0 => Err(super::error::last_os_error()),

--- a/tests/test_try_clone.rs
+++ b/tests/test_try_clone.rs
@@ -51,3 +51,25 @@ fn test_try_clone_move() {
     // The thread should have already ended, but we'll make sure here anyways.
     loopback.join().unwrap();
 }
+
+#[test]
+fn test_split() {
+    let (master, mut slave) = TTYPort::pair().expect("Unable to create ptty pair");
+
+    let (mut read_half, mut write_half) = master.split().expect("Failed to split");
+
+    let bytes = [b'm', b'n', b'o', b'p', b'q', b'r'];
+    write_half.write_all(&bytes).unwrap();
+
+    let mut buffer = [0; 6];
+    slave.read_exact(&mut buffer).unwrap();
+    assert_eq!(buffer, bytes);
+
+    // Also test reading from the split read_half
+    let slave_bytes = [b's', b't', b'u', b'v', b'w', b'x'];
+    slave.write_all(&slave_bytes).unwrap();
+
+    let mut buffer2 = [0; 6];
+    read_half.read_exact(&mut buffer2).unwrap();
+    assert_eq!(buffer2, slave_bytes);
+}


### PR DESCRIPTION
Resolves #250 and relates to tracking issue #302. 

While `try_clone()` allows concurrent reading and writing by duplicating the underlying OS handle, it forces developers to manage two full `SerialPort` instances, which can lead to accidental reads from the writing thread, writes from the reading thread, or conflicting configuration changes across threads. 

This PR introduces a split() method that cleanly separates a serial port into independent read and write halves, enforcing safer usage without requiring `Arc<Mutex<...>>` synchronization overhead in user space. It adds `ReadHalf<T>` and` WriteHalf<T>` wrappers in `src/lib.rs`, where `ReadHalf` is restricted to `std::io::Read` and `WriteHalf` to `std::io::Write`. The API is extended with pub `fn` split(self: Box<Self>) on `impl dyn SerialPort`, consuming the trait object to return independent halves, along with native split(self) implementations for `TTYPort` and `COMPort` to avoid heap allocation when using concrete types. 
Additionally, a `test_split` test is introduced in `tests/test_try_clone.rs` to verify correct splitting via `TTYPort::pair().split()` and ensure proper isolation of data flow between the read and write halves.