### PR TITLE
Fix write timeout being misreported as EOF on Windows

### DIFF
--- a/src/windows/com.rs
+++ b/src/windows/com.rs
@@ -248,7 +248,16 @@ impl io::Write for COMPort {
             )
         } {
             0 => Err(io::Error::last_os_error()),
-            _ => Ok(len as usize),
+            _ => {
+                if len != 0 {
+                    Ok(len as usize)
+                } else {
+                    Err(io::Error::new(
+                        io::ErrorKind::TimedOut,
+                        "Operation timed out",
+                    ))
+                }
+            }
         }
     }
 

--- a/src/windows/com.rs
+++ b/src/windows/com.rs
@@ -208,21 +208,25 @@ impl IntoRawHandle for COMPort {
 
 impl io::Read for COMPort {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        let mut len: u32 = 0;
+        let to_read: u32 = buf
+            .len()
+            .try_into()
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+        let mut read: u32 = 0;
 
         match unsafe {
             ReadFile(
                 self.handle,
                 buf.as_mut_ptr(),
-                buf.len() as u32,
-                &mut len,
+                to_read,
+                &mut read,
                 ptr::null_mut(),
             )
         } {
             0 => Err(io::Error::last_os_error()),
             _ => {
-                if len != 0 {
-                    Ok(len as usize)
+                if (to_read == 0 && read == 0) || (to_read > 0 && read != 0) {
+                    Ok(read as usize)
                 } else {
                     Err(io::Error::new(
                         io::ErrorKind::TimedOut,
@@ -236,21 +240,25 @@ impl io::Read for COMPort {
 
 impl io::Write for COMPort {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        let mut len: u32 = 0;
+        let to_write: u32 = buf
+            .len()
+            .try_into()
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+        let mut written: u32 = 0;
 
         match unsafe {
             WriteFile(
                 self.handle,
                 buf.as_ptr(),
-                buf.len() as u32,
-                &mut len,
+                to_write,
+                &mut written,
                 ptr::null_mut(),
             )
         } {
             0 => Err(io::Error::last_os_error()),
             _ => {
-                if len != 0 {
-                    Ok(len as usize)
+                if (to_write == 0 && written == 0) || (to_write > 0 && written != 0) {
+                    Ok(written as usize)
                 } else {
                     Err(io::Error::new(
                         io::ErrorKind::TimedOut,


### PR DESCRIPTION
When WriteFile succeeds but writes 0 bytes (i.e. a timeout), the write implementation previously returned Ok(0). This caused write_all to interpret the timeout as an unexpected EOF (Error::WRITE_ALL_EOF) instead of a timeout error.

Now, when WriteFile reports success with 0 bytes written, write returns Err(TimedOut) so that callers receive the correct error.