### PR TITLE
feat: add port_info() default method to SerialPort trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -472,6 +472,22 @@ pub trait SerialPort: Send + io::Read + io::Write {
     /// Additionally it may not exist for virtual ports.
     fn name(&self) -> Option<String>;
 
+    /// Returns the [`SerialPortInfo`] for this port by matching its name against
+    /// the results of [`available_ports()`].
+    ///
+    /// This may be slow on some platforms as it enumerates all available ports.
+    /// Returns an error if the port has no name, if enumeration fails, or if the
+    /// port is not found among the available ports (e.g. virtual or pseudo-terminal ports).
+    fn port_info(&self) -> Result<SerialPortInfo> {
+        let name = self
+            .name()
+            .ok_or_else(|| Error::new(ErrorKind::Unknown, "port has no name"))?;
+        available_ports()?
+            .into_iter()
+            .find(|info| info.port_name == name)
+            .ok_or_else(|| Error::new(ErrorKind::Unknown, "port not found in available ports"))
+    }
+
     /// Returns the current baud rate.
     ///
     /// This may return a value different from the last specified baud rate depending on the


### PR DESCRIPTION
Closes #276

## Problem

There is currently no way to retrieve `SerialPortInfo` from an open`dyn SerialPort` without calling `available_ports()` manually and searching by name.

## Solution

Add a default `port_info()` method to the `SerialPort` trait. The implementation calls `self.name()`, enumerates available ports, and returns the matching `SerialPortInfo` entry.

Since it is a default method, all existing implementors (`TTYPort`,`COMPort`, and the `&mut T` blanket impl) get it for free with no changes required on their end.

Returns `Err` if:
- the port has no name (e.g. virtual/pseudo-terminal ports)
- `available_ports()` fails
- no matching port is found

## Notes

- All existing tests pass
- Platform-specific types can override this method in the future
  if a faster implementation is needed (e.g. caching info at open time)