### PR TITLE
add port-chain feature for usb devices

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "rust-analyzer.cargo.features": [
-        "port-chain"
-    ]
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "rust-analyzer.cargo.features": [
+        "port-chain"
+    ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+
+* Provide USB port location in terms of bus and port chain via `UsbPortInfo`
+  and `Location`.
+  [#222](https://github.com/serialport/serialport-rs/issues/222)
+  [#350](https://github.com/serialport/serialport-rs/pull/350)
+
 ### Changed
 ### Fixed
 ### Removed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ rustversion = "1.0.16"
 [features]
 default = ["libudev"]
 hardware-tests = []
+port-chain = []
 # TODO: Make the feature unconditionally available with the next major release
 # (5.0) and remove this feature gate.
 usbportinfo-interface = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,8 @@ rustversion = "1.0.16"
 [features]
 default = ["libudev"]
 hardware-tests = []
-port-chain = []
-# TODO: Make the feature unconditionally available with the next major release
-# (5.0) and remove this feature gate.
+
+# TODO: Make the features below unconditionally available with the next major
+# release (5.0) and remove this feature gate.
+usbportinfo-chain = []
 usbportinfo-interface = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,5 +65,5 @@ hardware-tests = []
 
 # TODO: Make the features below unconditionally available with the next major
 # release (5.0) and remove this feature gate.
-usbportinfo-chain = []
 usbportinfo-interface = []
+usbportinfo-location = []

--- a/examples/list_ports.rs
+++ b/examples/list_ports.rs
@@ -39,9 +39,9 @@ fn main() {
                             "        Product: {}",
                             info.product.as_ref().map_or("", String::as_str)
                         );
-                        #[cfg(feature = "port-chain")]
+                        #[cfg(feature = "usbportinfo-chain")]
                         println!("        Bus ID: {}", info.bus_id);
-                        #[cfg(feature = "port-chain")]
+                        #[cfg(feature = "usbportinfo-chain")]
                         println!("        Port Chain: {:?}", info.port_chain);
                     }
                     SerialPortType::BluetoothPort => {

--- a/examples/list_ports.rs
+++ b/examples/list_ports.rs
@@ -39,7 +39,7 @@ fn main() {
                             "        Product: {}",
                             info.product.as_ref().map_or("", String::as_str)
                         );
-                        #[cfg(feature = "usbportinfo-chain")]
+                        #[cfg(feature = "usbportinfo-location")]
                         println!("        Location: {}", info.location);
                     }
                     SerialPortType::BluetoothPort => {

--- a/examples/list_ports.rs
+++ b/examples/list_ports.rs
@@ -39,6 +39,10 @@ fn main() {
                             "        Product: {}",
                             info.product.as_ref().map_or("", String::as_str)
                         );
+                        #[cfg(feature = "port-chain")]
+                        println!("        Bus ID: {}", info.bus_id);
+                        #[cfg(feature = "port-chain")]
+                        println!("        Port Chain: {:?}", info.port_chain);
                     }
                     SerialPortType::BluetoothPort => {
                         println!("        Type: Bluetooth");

--- a/examples/list_ports.rs
+++ b/examples/list_ports.rs
@@ -40,9 +40,7 @@ fn main() {
                             info.product.as_ref().map_or("", String::as_str)
                         );
                         #[cfg(feature = "usbportinfo-chain")]
-                        println!("        Bus ID: {}", info.bus_id);
-                        #[cfg(feature = "usbportinfo-chain")]
-                        println!("        Port Chain: {:?}", info.port_chain);
+                        println!("        Location: {}", info.location);
                     }
                     SerialPortType::BluetoothPort => {
                         println!("        Type: Bluetooth");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,8 @@
 use std::error::Error as StdError;
 use std::fmt;
 use std::io;
+#[cfg(feature = "usbportinfo-location")]
+use std::num::{IntErrorKind, ParseIntError};
 use std::str::FromStr;
 use std::time::Duration;
 
@@ -845,22 +847,6 @@ pub struct Location {
 }
 
 #[cfg(feature = "usbportinfo-location")]
-impl core::fmt::Display for Location {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
-        // Use a location format similat to Linux' sysfs 'bus-port.port[....]'.
-        //
-        // TODO: Switch to Iterator::intersperse when it get stabilized and available to us.
-        let port_chain = self
-            .port_chain
-            .iter()
-            .map(|p| p.to_string())
-            .collect::<Vec<_>>()
-            .join(".");
-        write!(f, "{}-{}", self.bus_id, port_chain)
-    }
-}
-
-#[cfg(feature = "usbportinfo-location")]
 impl Location {
     /// Create a new USB device location based on some string identifying the bus number, along with
     /// the path taken to a particular port.
@@ -897,6 +883,88 @@ impl Location {
             bus_id: self.bus_id.clone(),
             port_chain: self.port_chain[0..self.port_chain.len() - 1].to_owned(),
         })
+    }
+}
+
+#[cfg(feature = "usbportinfo-location")]
+impl fmt::Display for Location {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
+        // Use a location format similat to Linux' sysfs 'bus-port.port[....]'.
+        //
+        // TODO: Switch to Iterator::intersperse when it get stabilized and available to us.
+        let port_chain = self
+            .port_chain
+            .iter()
+            .map(|p| p.to_string())
+            .collect::<Vec<_>>()
+            .join(".");
+        write!(f, "{}-{}", self.bus_id, port_chain)
+    }
+}
+
+/// An error which can be returned when parsing a USB device location string.
+#[cfg(feature = "usbportinfo-location")]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct ParseLocationError {
+    kind: LocationErrorKind,
+}
+
+#[cfg(feature = "usbportinfo-location")]
+impl ParseLocationError {
+    /// Returns the detailed cause for parsing a USB device location failing.
+    pub fn kind(&self) -> &LocationErrorKind {
+        &self.kind
+    }
+}
+
+/// Enum to store the various types of errors that can cause parsing a USB device locaiton to fail.
+#[cfg(feature = "usbportinfo-location")]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[non_exhaustive]
+pub enum LocationErrorKind {
+    /// Parsing a port number in the port chain failed.
+    Port(IntErrorKind),
+    /// Parsing the top-level structure failed.
+    TopLevel,
+}
+
+#[cfg(feature = "usbportinfo-location")]
+impl From<ParseIntError> for ParseLocationError {
+    fn from(error: ParseIntError) -> ParseLocationError {
+        ParseLocationError {
+            kind: LocationErrorKind::Port(*error.kind()),
+        }
+    }
+}
+
+#[cfg(feature = "usbportinfo-location")]
+impl FromStr for Location {
+    type Err = ParseLocationError;
+
+    fn from_str(s: &str) -> std::result::Result<Location, Self::Err> {
+        let mut splits = s.split('-');
+
+        if let (Some(bus_id), Some(port_chain), None) =
+            (splits.next(), splits.next(), splits.next())
+        {
+            let bus_id = String::from(bus_id);
+            // We need to handle an empty port chain explicitly because otherwise the `split` would
+            // result in an empty port string for which parsing would fail.
+            let port_chain = if port_chain.is_empty() {
+                Vec::new()
+            } else {
+                port_chain
+                    .split('.')
+                    .map(|p| p.parse())
+                    .collect::<std::result::Result<Vec<u8>, _>>()?
+            };
+
+            Ok(Location { bus_id, port_chain })
+        } else {
+            Err(ParseLocationError {
+                kind: LocationErrorKind::TopLevel,
+            })
+        }
     }
 }
 
@@ -1060,5 +1128,112 @@ mod test {
         let expected = "UsbPortInfo { vid: 0xbade, pid: 0xaffe, serial_number: Some(\"your serial_number here\"), manufacturer: Some(\"your manufacutrer here\"), product: Some(\"your product here\"), interface: Some(42) }";
 
         assert_eq!(formatted, expected);
+    }
+
+    #[cfg(feature = "usbportinfo-location")]
+    mod usbportinfo_location {
+        use super::*;
+
+        // Empty fields are corner cases when we are not restricting the input inputs to
+        // `Location::new`. Let's have some test to ensure that they behave at least in a defined
+        // manner.
+        #[rstest]
+        #[case(Location { bus_id: String::new(), port_chain: vec![] }, "-")]
+        #[case(Location { bus_id: String::from("1"), port_chain: vec![] }, "1-")]
+        #[case(Location { bus_id: String::new(), port_chain: vec![1] }, "-1")]
+        fn display_empty_fields(#[case] location: Location, #[case] display: &str) {
+            assert_eq!(format!("{}", location), display);
+        }
+
+        #[rstest]
+        #[case(Location { bus_id: String::from("bus"), port_chain: vec![1, 2, 3]})]
+        #[case(Location { bus_id: String::from("1"), port_chain: vec![1, 2, 3]})]
+        #[case(Location { bus_id: String::from("001"), port_chain: vec![1, 2, 3]})]
+        fn display_from_str_cycle(#[case] start: Location) {
+            let display = format!("{}", start);
+            let from_str = Location::from_str(&display).unwrap();
+
+            assert_eq!(start, from_str);
+        }
+
+        #[rstest]
+        fn display_simple() {
+            let location = Location {
+                bus_id: String::from("bus"),
+                port_chain: vec![1, 2, 3],
+            };
+
+            assert_eq!(format!("{}", location), "bus-1.2.3",)
+        }
+
+        // Empty fields are corner cases when we are not restricting the input inputs to
+        // `Location::new`. Let's have some test to ensure that they behave at least in a defined
+        // manner.
+        #[rstest]
+        #[case("-", Location { bus_id: String::new(), port_chain: vec![]})]
+        #[case("1-", Location { bus_id: String::from("1"), port_chain: vec![]})]
+        #[case("-1", Location { bus_id: String::new(), port_chain: vec![1]})]
+        fn from_str_empty_fields(#[case] from: &str, #[case] location: Location) {
+            assert_eq!(Location::from_str(from).unwrap(), location);
+        }
+
+        #[rstest]
+        fn from_str_simple() {
+            assert_eq!(
+                Location::from_str("bus-1").unwrap(),
+                Location {
+                    bus_id: String::from("bus"),
+                    port_chain: vec![1],
+                }
+            );
+
+            assert_eq!(
+                Location::from_str("bus-255").unwrap(),
+                Location {
+                    bus_id: String::from("bus"),
+                    port_chain: vec![255],
+                }
+            );
+
+            assert_eq!(
+                Location::from_str("bus-1.2.3.4.5").unwrap(),
+                Location {
+                    bus_id: String::from("bus"),
+                    port_chain: vec![1, 2, 3, 4, 5],
+                }
+            );
+        }
+
+        #[rstest]
+        fn from_str_simple_invalid() {
+            matches!(
+                Location::from_str("").unwrap_err().kind(),
+                LocationErrorKind::TopLevel
+            );
+            matches!(
+                Location::from_str("bus").unwrap_err().kind(),
+                LocationErrorKind::TopLevel
+            );
+            matches!(
+                Location::from_str("bus-a").unwrap_err().kind(),
+                LocationErrorKind::Port(_)
+            );
+            matches!(
+                Location::from_str("bus-256").unwrap_err().kind(),
+                LocationErrorKind::Port(_)
+            );
+            matches!(
+                Location::from_str("bus-1-1").unwrap_err().kind(),
+                LocationErrorKind::TopLevel
+            );
+            matches!(
+                Location::from_str("bus-1..2").unwrap_err().kind(),
+                LocationErrorKind::TopLevel
+            );
+            matches!(
+                Location::from_str("bus-1.2.").unwrap_err().kind(),
+                LocationErrorKind::TopLevel
+            );
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -825,17 +825,74 @@ pub struct UsbPortInfo {
     pub manufacturer: Option<String>,
     /// Product name (arbitrary string)
     pub product: Option<String>,
-    /// ID of the USB bus where this device is connected
-    #[cfg(feature = "usbportinfo-chain")]
-    pub bus_id: String,
     /// Physical port heirarchy
     #[cfg(feature = "usbportinfo-chain")]
-    pub port_chain: Vec<u8>,
+    pub location: Location,
     /// The interface index of the USB serial port. This can be either the interface number of
     /// the communication interface (as is the case on Windows and Linux) or the data
     /// interface (as is the case on macOS), so you should recognize both interface numbers.
     #[cfg(feature = "usbportinfo-interface")]
     pub interface: Option<u8>,
+}
+
+#[cfg(feature = "usbportinfo-chain")]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+/// Identify where a particular USB device is on the system.
+pub struct Location {
+    bus_id: String,
+    port_chain: Vec<u8>,
+}
+
+#[cfg(feature = "usbportinfo-chain")]
+impl core::fmt::Display for Location {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {:?}", self.bus_id, self.port_chain)
+    }
+}
+
+#[cfg(feature = "usbportinfo-chain")]
+impl Location {
+    /// Create a new USB device location based on some string
+    /// identifying the bus number, along with the path taken
+    /// to a particular port.
+    pub fn new(bus_id: &str, port_chain: &[u8]) -> Self {
+        Location {
+            bus_id: bus_id.to_owned(),
+            port_chain: port_chain.to_owned(),
+        }
+    }
+
+    /// Returns `true` if this Location is located below
+    /// another Location in the bus heirarchy.
+    pub fn is_child_of(&self, other: &Location) -> bool {
+        self.bus_id == other.bus_id
+            && self.port_chain.starts_with(&other.port_chain)
+            && self.port_chain != other.port_chain
+    }
+
+    /// Returns the ID of the bus.
+    pub fn bus_id(&self) -> &str {
+        &self.bus_id
+    }
+
+    /// Returns a Vec of the port numbers needed to be traversed
+    /// to get to this device.
+    pub fn port_chain(&self) -> &[u8] {
+        &self.port_chain
+    }
+
+    /// Returns the parent of this device, if any. Root objects
+    /// have no parent.
+    pub fn parent(&self) -> Option<Location> {
+        if self.port_chain.len() <= 1 {
+            return None;
+        }
+        Some(Location {
+            bus_id: self.bus_id.clone(),
+            port_chain: self.port_chain[0..self.port_chain.len() - 1].to_owned(),
+        })
+    }
 }
 
 struct HexU16(u16);
@@ -984,9 +1041,7 @@ mod test {
             product: Some(String::from("your product here")),
             serial_number: Some(String::from("your serial_number here")),
             #[cfg(feature = "usbportinfo-chain")]
-            bus_id: String::from("001"),
-            #[cfg(feature = "usbportinfo-chain")]
-            port_chain: vec![],
+            location: Location::new("001", &[]),
             #[cfg(feature = "usbportinfo-interface")]
             interface: Some(42),
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -853,9 +853,8 @@ impl core::fmt::Display for Location {
 
 #[cfg(feature = "usbportinfo-chain")]
 impl Location {
-    /// Create a new USB device location based on some string
-    /// identifying the bus number, along with the path taken
-    /// to a particular port.
+    /// Create a new USB device location based on some string identifying the bus number, along with
+    /// the path taken to a particular port.
     pub fn new(bus_id: &str, port_chain: &[u8]) -> Self {
         Location {
             bus_id: bus_id.to_owned(),
@@ -863,8 +862,7 @@ impl Location {
         }
     }
 
-    /// Returns `true` if this Location is located below
-    /// another Location in the bus heirarchy.
+    /// Returns `true` if this Location is located below another Location in the bus hierarchy.
     pub fn is_child_of(&self, other: &Location) -> bool {
         self.bus_id == other.bus_id
             && self.port_chain.starts_with(&other.port_chain)
@@ -876,14 +874,12 @@ impl Location {
         &self.bus_id
     }
 
-    /// Returns a Vec of the port numbers needed to be traversed
-    /// to get to this device.
+    /// Returns a Vec of the port numbers needed to be traversed to get to this device.
     pub fn port_chain(&self) -> &[u8] {
         &self.port_chain
     }
 
-    /// Returns the parent of this device, if any. Root objects
-    /// have no parent.
+    /// Returns the parent of this device, if any. Root objects have no parent.
     pub fn parent(&self) -> Option<Location> {
         if self.port_chain.len() <= 1 {
             return None;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -826,10 +826,10 @@ pub struct UsbPortInfo {
     /// Product name (arbitrary string)
     pub product: Option<String>,
     /// ID of the USB bus where this device is connected
-    #[cfg(feature = "port-chain")]
+    #[cfg(feature = "usbportinfo-chain")]
     pub bus_id: String,
     /// Physical port heirarchy
-    #[cfg(feature = "port-chain")]
+    #[cfg(feature = "usbportinfo-chain")]
     pub port_chain: Vec<u8>,
     /// The interface index of the USB serial port. This can be either the interface number of
     /// the communication interface (as is the case on Windows and Linux) or the data
@@ -983,9 +983,9 @@ mod test {
             pid: 0xaffe,
             product: Some(String::from("your product here")),
             serial_number: Some(String::from("your serial_number here")),
-            #[cfg(feature = "port-chain")]
+            #[cfg(feature = "usbportinfo-chain")]
             bus_id: String::from("001"),
-            #[cfg(feature = "port-chain")]
+            #[cfg(feature = "usbportinfo-chain")]
             port_chain: vec![],
             #[cfg(feature = "usbportinfo-interface")]
             interface: Some(42),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -847,7 +847,16 @@ pub struct Location {
 #[cfg(feature = "usbportinfo-chain")]
 impl core::fmt::Display for Location {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}: {:?}", self.bus_id, self.port_chain)
+        // Use a location format similat to Linux' sysfs 'bus-port.port[....]'.
+        //
+        // TODO: Switch to Iterator::intersperse when it get stabilized and available to us.
+        let port_chain = self
+            .port_chain
+            .iter()
+            .map(|p| p.to_string())
+            .collect::<Vec<_>>()
+            .join(".");
+        write!(f, "{}-{}", self.bus_id, port_chain)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1235,5 +1235,78 @@ mod test {
                 LocationErrorKind::TopLevel
             );
         }
+
+        #[rstest]
+        fn is_descendand_of() {
+            let child = Location {
+                bus_id: String::from("bus"),
+                port_chain: vec![1, 2, 3],
+            };
+            let parent = Location {
+                bus_id: String::from("bus"),
+                port_chain: vec![1, 2],
+            };
+            let grandparent = Location {
+                bus_id: String::from("bus"),
+                port_chain: vec![1],
+            };
+            let empty_port_chain = Location {
+                bus_id: String::from("bus"),
+                port_chain: vec![],
+            };
+
+            assert!(child.is_descendant_of(&empty_port_chain));
+            assert!(parent.is_descendant_of(&empty_port_chain));
+            assert!(grandparent.is_descendant_of(&empty_port_chain));
+            assert!(!empty_port_chain.is_descendant_of(&empty_port_chain));
+
+            assert!(child.is_descendant_of(&grandparent));
+            assert!(parent.is_descendant_of(&grandparent));
+            assert!(!grandparent.is_descendant_of(&grandparent));
+            assert!(!empty_port_chain.is_descendant_of(&grandparent));
+
+            assert!(child.is_descendant_of(&parent));
+            assert!(!parent.is_descendant_of(&parent));
+            assert!(!grandparent.is_descendant_of(&parent));
+            assert!(!empty_port_chain.is_descendant_of(&parent));
+
+            assert!(!child.is_descendant_of(&child));
+            assert!(!parent.is_descendant_of(&child));
+            assert!(!grandparent.is_descendant_of(&child));
+            assert!(!empty_port_chain.is_descendant_of(&child));
+
+            let different_parent = Location {
+                bus_id: String::from("another_bus"),
+                port_chain: vec![1, 2],
+            };
+
+            assert!(!child.is_descendant_of(&different_parent));
+        }
+
+        #[rstest]
+        fn parent() {
+            let child = Location {
+                bus_id: String::from("bus"),
+                port_chain: vec![1, 2, 3],
+            };
+            let parent = Location {
+                bus_id: String::from("bus"),
+                port_chain: vec![1, 2],
+            };
+            let grandparent = Location {
+                bus_id: String::from("bus"),
+                port_chain: vec![1],
+            };
+            let empty_port_chain = Location {
+                bus_id: String::from("bus"),
+                port_chain: vec![1],
+            };
+
+            assert_eq!(child.parent(), Some(parent.clone()));
+            assert_eq!(parent.parent(), Some(grandparent.clone()));
+
+            assert!(grandparent.parent().is_none());
+            assert!(empty_port_chain.parent().is_none());
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -858,7 +858,7 @@ impl Location {
     }
 
     /// Returns `true` if this Location is located below another Location in the bus hierarchy.
-    pub fn is_child_of(&self, other: &Location) -> bool {
+    pub fn is_descendant_of(&self, other: &Location) -> bool {
         self.bus_id == other.bus_id
             && self.port_chain.starts_with(&other.port_chain)
             && self.port_chain != other.port_chain

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -826,7 +826,7 @@ pub struct UsbPortInfo {
     /// Product name (arbitrary string)
     pub product: Option<String>,
     /// Physical port heirarchy
-    #[cfg(feature = "usbportinfo-chain")]
+    #[cfg(feature = "usbportinfo-location")]
     pub location: Location,
     /// The interface index of the USB serial port. This can be either the interface number of
     /// the communication interface (as is the case on Windows and Linux) or the data
@@ -835,7 +835,7 @@ pub struct UsbPortInfo {
     pub interface: Option<u8>,
 }
 
-#[cfg(feature = "usbportinfo-chain")]
+#[cfg(feature = "usbportinfo-location")]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// Identify where a particular USB device is on the system.
@@ -844,7 +844,7 @@ pub struct Location {
     port_chain: Vec<u8>,
 }
 
-#[cfg(feature = "usbportinfo-chain")]
+#[cfg(feature = "usbportinfo-location")]
 impl core::fmt::Display for Location {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
         // Use a location format similat to Linux' sysfs 'bus-port.port[....]'.
@@ -860,7 +860,7 @@ impl core::fmt::Display for Location {
     }
 }
 
-#[cfg(feature = "usbportinfo-chain")]
+#[cfg(feature = "usbportinfo-location")]
 impl Location {
     /// Create a new USB device location based on some string identifying the bus number, along with
     /// the path taken to a particular port.
@@ -1045,7 +1045,7 @@ mod test {
             pid: 0xaffe,
             product: Some(String::from("your product here")),
             serial_number: Some(String::from("your serial_number here")),
-            #[cfg(feature = "usbportinfo-chain")]
+            #[cfg(feature = "usbportinfo-location")]
             location: Location::new("001", &[]),
             #[cfg(feature = "usbportinfo-interface")]
             interface: Some(42),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -825,6 +825,12 @@ pub struct UsbPortInfo {
     pub manufacturer: Option<String>,
     /// Product name (arbitrary string)
     pub product: Option<String>,
+    /// ID of the USB bus where this device is connected
+    #[cfg(feature = "port-chain")]
+    pub bus_id: String,
+    /// Physical port heirarchy
+    #[cfg(feature = "port-chain")]
+    pub port_chain: Vec<u8>,
     /// The interface index of the USB serial port. This can be either the interface number of
     /// the communication interface (as is the case on Windows and Linux) or the data
     /// interface (as is the case on macOS), so you should recognize both interface numbers.
@@ -977,6 +983,10 @@ mod test {
             pid: 0xaffe,
             product: Some(String::from("your product here")),
             serial_number: Some(String::from("your serial_number here")),
+            #[cfg(feature = "port-chain")]
+            bus_id: String::from("001"),
+            #[cfg(feature = "port-chain")]
+            port_chain: vec![],
             #[cfg(feature = "usbportinfo-interface")]
             interface: Some(42),
         };

--- a/src/posix/enumerate.rs
+++ b/src/posix/enumerate.rs
@@ -345,6 +345,20 @@ fn get_string_property(device_type: io_registry_entry_t, property: &str) -> Resu
         .ok_or(Error::new(ErrorKind::Unknown, "Failed to get string value"))
 }
 
+#[cfg(all(any(target_os = "ios", target_os = "macos"), feature = "port-chain"))]
+fn parse_location_id(id: u32) -> Vec<u8> {
+    let mut chain = vec![];
+    let mut shift = id << 8;
+
+    while shift != 0 {
+        let port = shift >> 28;
+        chain.push(port as u8);
+        shift <<= 4;
+    }
+
+    chain
+}
+
 #[cfg(any(target_os = "ios", target_os = "macos"))]
 /// Determine the serial port type based on the service object (like that returned by
 /// `IOIteratorNext`). Specific properties are extracted for USB devices.
@@ -356,12 +370,18 @@ fn port_type(service: io_object_t) -> SerialPortType {
     let maybe_usb_device = get_parent_device_by_type(service, usb_device_class_name)
         .or_else(|| get_parent_device_by_type(service, legacy_usb_device_class_name));
     if let Some(usb_device) = maybe_usb_device {
+        #[cfg(feature = "port-chain")]
+        let location_id = get_int_property(usb_device, "locationID").unwrap_or_default();
         SerialPortType::UsbPort(UsbPortInfo {
             vid: get_int_property(usb_device, "idVendor").unwrap_or_default() as u16,
             pid: get_int_property(usb_device, "idProduct").unwrap_or_default() as u16,
             serial_number: get_string_property(usb_device, "USB Serial Number").ok(),
             manufacturer: get_string_property(usb_device, "USB Vendor Name").ok(),
             product: get_string_property(usb_device, "USB Product Name").ok(),
+            #[cfg(feature = "port-chain")]
+            bus_id: format!("{:02x}", (location_id >> 24) as u8),
+            #[cfg(feature = "port-chain")]
+            port_chain: parse_location_id(location_id),
             // Apple developer documentation indicates `bInterfaceNumber` is the supported key for
             // looking up the composite usb interface id. `idVendor` and `idProduct` are included in the same tables, so
             // we will lookup the interface number using the same method. See:
@@ -602,12 +622,35 @@ cfg_if! {
             let product = read_file_to_trimmed_string(&device_path, &"product");
             let manufacturer = read_file_to_trimmed_string(&device_path, &"manufacturer");
 
+            #[cfg(feature = "port-chain")]
+            let bus_id = if let Some(busnum) = read_file_to_trimmed_string(&device_path, "busnum") {
+                u32::from_str_radix(&busnum, 10)
+                .map(|n| format!("{n:03}"))
+                .unwrap_or_default()
+            } else {
+                "000".to_owned()
+            };
+
+            #[cfg(feature = "port-chain")]
+            let port_chain = read_file_to_trimmed_string(&device_path, "devpath")
+                .filter(|p| p != "0") // root hub should be empty but devpath is 0
+                .and_then(|p| {
+                    p.split('.')
+                        .map(|v| v.parse::<u8>().ok())
+                        .collect::<Option<Vec<u8>>>()
+                })
+                .unwrap_or_default();
+
             Some(UsbPortInfo {
                 vid,
                 pid,
                 serial_number,
                 manufacturer,
                 product,
+                #[cfg(feature = "port-chain")]
+                bus_id,
+                #[cfg(feature = "port-chain")]
+                port_chain,
                 #[cfg(feature = "usbportinfo-interface")]
                 interface,
             })

--- a/src/posix/enumerate.rs
+++ b/src/posix/enumerate.rs
@@ -46,6 +46,12 @@ use crate::UsbPortInfo;
 use crate::{Error, ErrorKind};
 use crate::{Result, SerialPortInfo};
 
+cfg_if! {
+    if #[cfg(feature = "usbportinfo-chain")] {
+        use crate::Location;
+    }
+}
+
 /// Retrieves the udev property value named by `key`. If the value exists, then it will be
 /// converted to a String, otherwise None will be returned.
 #[cfg(all(target_os = "linux", not(target_env = "musl"), feature = "libudev"))]
@@ -116,7 +122,7 @@ fn udev_restore_spaces(source: String) -> String {
 ))]
 /// Get the bus number and port chain out of the first parent device that
 /// has a defined bus number.
-fn bus_num_and_port_chain(device: &libudev::Device) -> (String, Vec<u8>) {
+fn port_location(device: &libudev::Device) -> Location {
     let mut device = device.parent();
     while let Some(d) = device.take() {
         let busnum = udev_property_as_string(&d, "BUSNUM");
@@ -152,10 +158,10 @@ fn bus_num_and_port_chain(device: &libudev::Device) -> (String, Vec<u8>) {
                     .collect::<Option<Vec<u8>>>()
             })
             .unwrap_or_default();
-        return (bus_num, port_chain);
+        return Location::new(&bus_num, &port_chain);
     }
 
-    ("000".to_owned(), vec![])
+    Location::new("000", &[])
 }
 
 #[cfg(all(target_os = "linux", not(target_env = "musl"), feature = "libudev"))]
@@ -174,7 +180,7 @@ fn port_type(d: &libudev::Device) -> Result<SerialPortType> {
                     .or_else(|| udev_property_as_string(d, "ID_MODEL_FROM_DATABASE"));
 
             #[cfg(feature = "usbportinfo-chain")]
-            let (bus_id, port_chain) = bus_num_and_port_chain(d);
+            let location = port_location(d);
 
             Ok(SerialPortType::UsbPort(UsbPortInfo {
                 vid: udev_hex_property_as_int(d, "ID_VENDOR_ID", &u16::from_str_radix)?,
@@ -183,9 +189,7 @@ fn port_type(d: &libudev::Device) -> Result<SerialPortType> {
                 manufacturer,
                 product,
                 #[cfg(feature = "usbportinfo-chain")]
-                bus_id,
-                #[cfg(feature = "usbportinfo-chain")]
-                port_chain,
+                location,
                 #[cfg(feature = "usbportinfo-interface")]
                 interface: udev_hex_property_as_int(d, "ID_USB_INTERFACE_NUM", &u8::from_str_radix)
                     .ok(),
@@ -213,7 +217,7 @@ fn port_type(d: &libudev::Device) -> Result<SerialPortType> {
                 );
 
                 #[cfg(feature = "usbportinfo-chain")]
-                let (bus_id, port_chain) = bus_num_and_port_chain(d);
+                let location = port_location(d);
 
                 Ok(SerialPortType::UsbPort(UsbPortInfo {
                     vid: udev_hex_property_as_int(d, "ID_USB_VENDOR_ID", &u16::from_str_radix)?,
@@ -222,9 +226,7 @@ fn port_type(d: &libudev::Device) -> Result<SerialPortType> {
                     manufacturer,
                     product,
                     #[cfg(feature = "usbportinfo-chain")]
-                    bus_id,
-                    #[cfg(feature = "usbportinfo-chain")]
-                    port_chain,
+                    location,
                     #[cfg(feature = "usbportinfo-interface")]
                     interface: udev_hex_property_as_int(
                         d,
@@ -319,9 +321,7 @@ fn parse_modalias(moda: &str) -> Option<UsbPortInfo> {
         manufacturer: None,
         product: None,
         #[cfg(feature = "usbportinfo-chain")]
-        bus_id: Default::default(),
-        #[cfg(feature = "usbportinfo-chain")]
-        port_chain: Default::default(),
+        location: Default::default(),
         // Only attempt to find the interface if the feature is enabled.
         #[cfg(feature = "usbportinfo-interface")]
         interface: mod_tail.get(pid_start + 4..).and_then(|mod_tail| {
@@ -695,23 +695,26 @@ cfg_if! {
             let manufacturer = read_file_to_trimmed_string(device_path, "manufacturer");
 
             #[cfg(feature = "usbportinfo-chain")]
-            let bus_id = if let Some(busnum) = read_file_to_trimmed_string(device_path, "busnum") {
-                u32::from_str_radix(&busnum, 10)
-                .map(|n| format!("{n:03}"))
-                .unwrap_or_default()
-            } else {
-                "000".to_owned()
-            };
+            let location = {
+                let bus_id = if let Some(busnum) = read_file_to_trimmed_string(device_path, "busnum") {
+                    u32::from_str_radix(&busnum, 10)
+                    .map(|n| format!("{n:03}"))
+                    .unwrap_or_default()
+                } else {
+                    "000".to_owned()
+                };
 
-            #[cfg(feature = "usbportinfo-chain")]
-            let port_chain = read_file_to_trimmed_string(device_path, "devpath")
-                .filter(|p| p != "0") // root hub should be empty but devpath is 0
-                .and_then(|p| {
-                    p.split('.')
-                        .map(|v| v.parse::<u8>().ok())
-                        .collect::<Option<Vec<u8>>>()
-                })
-                .unwrap_or_default();
+                let port_chain = read_file_to_trimmed_string(device_path, "devpath")
+                    .filter(|p| p != "0") // root hub should be empty but devpath is 0
+                    .and_then(|p| {
+                        p.split('.')
+                            .map(|v| v.parse::<u8>().ok())
+                            .collect::<Option<Vec<u8>>>()
+                    })
+                    .unwrap_or_default();
+
+                Location::new(&bus_id, &port_chain)
+            };
 
             Some(UsbPortInfo {
                 vid,
@@ -720,9 +723,7 @@ cfg_if! {
                 manufacturer,
                 product,
                 #[cfg(feature = "usbportinfo-chain")]
-                bus_id,
-                #[cfg(feature = "usbportinfo-chain")]
-                port_chain,
+                location,
                 #[cfg(feature = "usbportinfo-interface")]
                 interface,
             })

--- a/src/posix/enumerate.rs
+++ b/src/posix/enumerate.rs
@@ -137,8 +137,9 @@ fn bus_num_and_port_chain(device: &libudev::Device) -> (String, Vec<u8>) {
         };
         let devpath = devpath.unwrap();
 
-        let bus_num = u32::from_str_radix(&busnum, 10)
-            .map(|n| format!("{n:03}"))
+        let bus_num = busnum
+            .parse()
+            .map(|n: u32| format!("{n:03}"))
             .unwrap_or_default();
 
         let port_chain = devpath
@@ -153,7 +154,8 @@ fn bus_num_and_port_chain(device: &libudev::Device) -> (String, Vec<u8>) {
             .unwrap_or_default();
         return (bus_num, port_chain);
     }
-    return ("000".to_owned(), vec![]);
+
+    ("000".to_owned(), vec![])
 }
 
 #[cfg(all(target_os = "linux", not(target_env = "musl"), feature = "libudev"))]

--- a/src/posix/enumerate.rs
+++ b/src/posix/enumerate.rs
@@ -116,7 +116,7 @@ fn udev_restore_spaces(source: String) -> String {
 ))]
 /// Get the bus number and port chain out of the first parent device that
 /// has a defined bus number.
-fn port_location(device: &libudev::Device) -> Location {
+fn port_location(device: &libudev::Device) -> crate::Location {
     let mut device = device.parent();
     while let Some(d) = device.take() {
         let busnum = udev_property_as_string(&d, "BUSNUM");

--- a/src/posix/enumerate.rs
+++ b/src/posix/enumerate.rs
@@ -112,7 +112,7 @@ fn udev_restore_spaces(source: String) -> String {
 #[cfg(all(
     target_os = "linux",
     not(target_env = "musl"),
-    all(feature = "libudev", feature = "port-chain")
+    all(feature = "libudev", feature = "usbportinfo-chain")
 ))]
 /// Get the bus number and port chain out of the first parent device that
 /// has a defined bus number.
@@ -171,7 +171,7 @@ fn port_type(d: &libudev::Device) -> Result<SerialPortType> {
                 udev_property_encoded_or_replaced_as_string(d, "ID_MODEL_ENC", "ID_MODEL")
                     .or_else(|| udev_property_as_string(d, "ID_MODEL_FROM_DATABASE"));
 
-            #[cfg(feature = "port-chain")]
+            #[cfg(feature = "usbportinfo-chain")]
             let (bus_id, port_chain) = bus_num_and_port_chain(d);
 
             Ok(SerialPortType::UsbPort(UsbPortInfo {
@@ -180,9 +180,9 @@ fn port_type(d: &libudev::Device) -> Result<SerialPortType> {
                 serial_number,
                 manufacturer,
                 product,
-                #[cfg(feature = "port-chain")]
+                #[cfg(feature = "usbportinfo-chain")]
                 bus_id,
-                #[cfg(feature = "port-chain")]
+                #[cfg(feature = "usbportinfo-chain")]
                 port_chain,
                 #[cfg(feature = "usbportinfo-interface")]
                 interface: udev_hex_property_as_int(d, "ID_USB_INTERFACE_NUM", &u8::from_str_radix)
@@ -210,7 +210,7 @@ fn port_type(d: &libudev::Device) -> Result<SerialPortType> {
                     "ID_USB_MODEL",
                 );
 
-                #[cfg(feature = "port-chain")]
+                #[cfg(feature = "usbportinfo-chain")]
                 let (bus_id, port_chain) = bus_num_and_port_chain(d);
 
                 Ok(SerialPortType::UsbPort(UsbPortInfo {
@@ -219,9 +219,9 @@ fn port_type(d: &libudev::Device) -> Result<SerialPortType> {
                     serial_number: udev_property_as_string(d, "ID_USB_SERIAL_SHORT"),
                     manufacturer,
                     product,
-                    #[cfg(feature = "port-chain")]
+                    #[cfg(feature = "usbportinfo-chain")]
                     bus_id,
-                    #[cfg(feature = "port-chain")]
+                    #[cfg(feature = "usbportinfo-chain")]
                     port_chain,
                     #[cfg(feature = "usbportinfo-interface")]
                     interface: udev_hex_property_as_int(
@@ -316,9 +316,9 @@ fn parse_modalias(moda: &str) -> Option<UsbPortInfo> {
         serial_number: None,
         manufacturer: None,
         product: None,
-        #[cfg(feature = "port-chain")]
+        #[cfg(feature = "usbportinfo-chain")]
         bus_id: Default::default(),
-        #[cfg(feature = "port-chain")]
+        #[cfg(feature = "usbportinfo-chain")]
         port_chain: Default::default(),
         // Only attempt to find the interface if the feature is enabled.
         #[cfg(feature = "usbportinfo-interface")]
@@ -412,7 +412,10 @@ fn get_string_property(device_type: io_registry_entry_t, property: &str) -> Resu
         .ok_or(Error::new(ErrorKind::Unknown, "Failed to get string value"))
 }
 
-#[cfg(all(any(target_os = "ios", target_os = "macos"), feature = "port-chain"))]
+#[cfg(all(
+    any(target_os = "ios", target_os = "macos"),
+    feature = "usbportinfo-chain"
+))]
 fn parse_location_id(id: u32) -> Vec<u8> {
     let mut chain = vec![];
     let mut shift = id << 8;
@@ -437,7 +440,7 @@ fn port_type(service: io_object_t) -> SerialPortType {
     let maybe_usb_device = get_parent_device_by_type(service, usb_device_class_name)
         .or_else(|| get_parent_device_by_type(service, legacy_usb_device_class_name));
     if let Some(usb_device) = maybe_usb_device {
-        #[cfg(feature = "port-chain")]
+        #[cfg(feature = "usbportinfo-chain")]
         let location_id = get_int_property(usb_device, "locationID").unwrap_or_default();
         SerialPortType::UsbPort(UsbPortInfo {
             vid: get_int_property(usb_device, "idVendor").unwrap_or_default() as u16,
@@ -445,9 +448,9 @@ fn port_type(service: io_object_t) -> SerialPortType {
             serial_number: get_string_property(usb_device, "USB Serial Number").ok(),
             manufacturer: get_string_property(usb_device, "USB Vendor Name").ok(),
             product: get_string_property(usb_device, "USB Product Name").ok(),
-            #[cfg(feature = "port-chain")]
+            #[cfg(feature = "usbportinfo-chain")]
             bus_id: format!("{:02x}", (location_id >> 24) as u8),
-            #[cfg(feature = "port-chain")]
+            #[cfg(feature = "usbportinfo-chain")]
             port_chain: parse_location_id(location_id),
             // Apple developer documentation indicates `bInterfaceNumber` is the supported key for
             // looking up the composite usb interface id. `idVendor` and `idProduct` are included in the same tables, so
@@ -689,7 +692,7 @@ cfg_if! {
             let product = read_file_to_trimmed_string(device_path, "product");
             let manufacturer = read_file_to_trimmed_string(device_path, "manufacturer");
 
-            #[cfg(feature = "port-chain")]
+            #[cfg(feature = "usbportinfo-chain")]
             let bus_id = if let Some(busnum) = read_file_to_trimmed_string(device_path, "busnum") {
                 u32::from_str_radix(&busnum, 10)
                 .map(|n| format!("{n:03}"))
@@ -698,7 +701,7 @@ cfg_if! {
                 "000".to_owned()
             };
 
-            #[cfg(feature = "port-chain")]
+            #[cfg(feature = "usbportinfo-chain")]
             let port_chain = read_file_to_trimmed_string(device_path, "devpath")
                 .filter(|p| p != "0") // root hub should be empty but devpath is 0
                 .and_then(|p| {
@@ -714,9 +717,9 @@ cfg_if! {
                 serial_number,
                 manufacturer,
                 product,
-                #[cfg(feature = "port-chain")]
+                #[cfg(feature = "usbportinfo-chain")]
                 bus_id,
-                #[cfg(feature = "port-chain")]
+                #[cfg(feature = "usbportinfo-chain")]
                 port_chain,
                 #[cfg(feature = "usbportinfo-interface")]
                 interface,

--- a/src/posix/enumerate.rs
+++ b/src/posix/enumerate.rs
@@ -451,9 +451,10 @@ fn port_type(service: io_object_t) -> SerialPortType {
             manufacturer: get_string_property(usb_device, "USB Vendor Name").ok(),
             product: get_string_property(usb_device, "USB Product Name").ok(),
             #[cfg(feature = "usbportinfo-chain")]
-            bus_id: format!("{:02x}", (location_id >> 24) as u8),
-            #[cfg(feature = "usbportinfo-chain")]
-            port_chain: parse_location_id(location_id),
+            location: Location::new(
+                &format!("{:02x}", (location_id >> 24) as u8),
+                &parse_location_id(location_id),
+            ),
             // Apple developer documentation indicates `bInterfaceNumber` is the supported key for
             // looking up the composite usb interface id. `idVendor` and `idProduct` are included in the same tables, so
             // we will lookup the interface number using the same method. See:

--- a/src/posix/enumerate.rs
+++ b/src/posix/enumerate.rs
@@ -614,13 +614,13 @@ cfg_if! {
         fn read_usb_port_info(interface_path: &Path) -> Option<UsbPortInfo> {
             let device_path = interface_path.parent()?;
 
-            let vid = read_file_to_u16(&device_path, "idVendor")?;
-            let pid = read_file_to_u16(&device_path, "idProduct")?;
+            let vid = read_file_to_u16(device_path, "idVendor")?;
+            let pid = read_file_to_u16(device_path, "idProduct")?;
             #[cfg(feature = "usbportinfo-interface")]
             let interface = read_file_to_u8(&interface_path, &"bInterfaceNumber");
-            let serial_number = read_file_to_trimmed_string(&device_path, &"serial");
-            let product = read_file_to_trimmed_string(&device_path, &"product");
-            let manufacturer = read_file_to_trimmed_string(&device_path, &"manufacturer");
+            let serial_number = read_file_to_trimmed_string(device_path, "serial");
+            let product = read_file_to_trimmed_string(device_path, "product");
+            let manufacturer = read_file_to_trimmed_string(device_path, "manufacturer");
 
             #[cfg(feature = "port-chain")]
             let bus_id = if let Some(busnum) = read_file_to_trimmed_string(&device_path, "busnum") {

--- a/src/posix/enumerate.rs
+++ b/src/posix/enumerate.rs
@@ -123,13 +123,19 @@ fn bus_num_and_port_chain(device: &libudev::Device) -> (String, Vec<u8>) {
         let devpath = d.devpath().and_then(OsStr::to_str);
         device = d.parent();
 
-        let Some(busnum) = busnum else {
+        // TODO: Replace this with `if let Some(busnum) = busnum else { continue };`
+        // when MSRV is updated.
+        if busnum.is_none() {
             continue;
-        };
+        }
+        let busnum = busnum.unwrap();
 
-        let Some(devpath) = devpath else {
+        // TODO: Replace this with `if let Some(devpath) = devpath else { continue };`
+        // when MSRV is updated.
+        if devpath.is_none() {
             continue;
         };
+        let devpath = devpath.unwrap();
 
         let bus_num = u32::from_str_radix(&busnum, 10)
             .map(|n| format!("{n:03}"))

--- a/src/posix/enumerate.rs
+++ b/src/posix/enumerate.rs
@@ -112,7 +112,7 @@ fn udev_restore_spaces(source: String) -> String {
 #[cfg(all(
     target_os = "linux",
     not(target_env = "musl"),
-    all(feature = "libudev", feature = "usbportinfo-chain")
+    all(feature = "libudev", feature = "usbportinfo-location")
 ))]
 /// Get the bus number and port chain out of the first parent device that
 /// has a defined bus number.
@@ -173,7 +173,7 @@ fn port_type(d: &libudev::Device) -> Result<SerialPortType> {
                 udev_property_encoded_or_replaced_as_string(d, "ID_MODEL_ENC", "ID_MODEL")
                     .or_else(|| udev_property_as_string(d, "ID_MODEL_FROM_DATABASE"));
 
-            #[cfg(feature = "usbportinfo-chain")]
+            #[cfg(feature = "usbportinfo-location")]
             let location = port_location(d);
 
             Ok(SerialPortType::UsbPort(UsbPortInfo {
@@ -182,7 +182,7 @@ fn port_type(d: &libudev::Device) -> Result<SerialPortType> {
                 serial_number,
                 manufacturer,
                 product,
-                #[cfg(feature = "usbportinfo-chain")]
+                #[cfg(feature = "usbportinfo-location")]
                 location,
                 #[cfg(feature = "usbportinfo-interface")]
                 interface: udev_hex_property_as_int(d, "ID_USB_INTERFACE_NUM", &u8::from_str_radix)
@@ -210,7 +210,7 @@ fn port_type(d: &libudev::Device) -> Result<SerialPortType> {
                     "ID_USB_MODEL",
                 );
 
-                #[cfg(feature = "usbportinfo-chain")]
+                #[cfg(feature = "usbportinfo-location")]
                 let location = port_location(d);
 
                 Ok(SerialPortType::UsbPort(UsbPortInfo {
@@ -219,7 +219,7 @@ fn port_type(d: &libudev::Device) -> Result<SerialPortType> {
                     serial_number: udev_property_as_string(d, "ID_USB_SERIAL_SHORT"),
                     manufacturer,
                     product,
-                    #[cfg(feature = "usbportinfo-chain")]
+                    #[cfg(feature = "usbportinfo-location")]
                     location,
                     #[cfg(feature = "usbportinfo-interface")]
                     interface: udev_hex_property_as_int(
@@ -314,7 +314,7 @@ fn parse_modalias(moda: &str) -> Option<UsbPortInfo> {
         serial_number: None,
         manufacturer: None,
         product: None,
-        #[cfg(feature = "usbportinfo-chain")]
+        #[cfg(feature = "usbportinfo-location")]
         location: Default::default(),
         // Only attempt to find the interface if the feature is enabled.
         #[cfg(feature = "usbportinfo-interface")]
@@ -410,7 +410,7 @@ fn get_string_property(device_type: io_registry_entry_t, property: &str) -> Resu
 
 #[cfg(all(
     any(target_os = "ios", target_os = "macos"),
-    feature = "usbportinfo-chain"
+    feature = "usbportinfo-location"
 ))]
 fn parse_location_id(id: u32) -> Vec<u8> {
     let mut chain = vec![];
@@ -436,7 +436,7 @@ fn port_type(service: io_object_t) -> SerialPortType {
     let maybe_usb_device = get_parent_device_by_type(service, usb_device_class_name)
         .or_else(|| get_parent_device_by_type(service, legacy_usb_device_class_name));
     if let Some(usb_device) = maybe_usb_device {
-        #[cfg(feature = "usbportinfo-chain")]
+        #[cfg(feature = "usbportinfo-location")]
         let location_id = get_int_property(usb_device, "locationID").unwrap_or_default();
         SerialPortType::UsbPort(UsbPortInfo {
             vid: get_int_property(usb_device, "idVendor").unwrap_or_default() as u16,
@@ -444,7 +444,7 @@ fn port_type(service: io_object_t) -> SerialPortType {
             serial_number: get_string_property(usb_device, "USB Serial Number").ok(),
             manufacturer: get_string_property(usb_device, "USB Vendor Name").ok(),
             product: get_string_property(usb_device, "USB Product Name").ok(),
-            #[cfg(feature = "usbportinfo-chain")]
+            #[cfg(feature = "usbportinfo-location")]
             location: crate::Location::new(
                 &format!("{:02x}", (location_id >> 24) as u8),
                 &parse_location_id(location_id),
@@ -689,7 +689,7 @@ cfg_if! {
             let product = read_file_to_trimmed_string(device_path, "product");
             let manufacturer = read_file_to_trimmed_string(device_path, "manufacturer");
 
-            #[cfg(feature = "usbportinfo-chain")]
+            #[cfg(feature = "usbportinfo-location")]
             let location = {
                 let bus_id = if let Some(busnum) = read_file_to_trimmed_string(device_path, "busnum") {
                     u32::from_str_radix(&busnum, 10)
@@ -717,7 +717,7 @@ cfg_if! {
                 serial_number,
                 manufacturer,
                 product,
-                #[cfg(feature = "usbportinfo-chain")]
+                #[cfg(feature = "usbportinfo-location")]
                 location,
                 #[cfg(feature = "usbportinfo-interface")]
                 interface,

--- a/src/posix/enumerate.rs
+++ b/src/posix/enumerate.rs
@@ -109,6 +109,47 @@ fn udev_restore_spaces(source: String) -> String {
     source.replace('_', " ")
 }
 
+#[cfg(all(
+    target_os = "linux",
+    not(target_env = "musl"),
+    all(feature = "libudev", feature = "port-chain")
+))]
+/// Get the bus number and port chain out of the first parent device that
+/// has a defined bus number.
+fn bus_num_and_port_chain(device: &libudev::Device) -> (String, Vec<u8>) {
+    let mut device = device.parent();
+    while let Some(d) = device.take() {
+        let busnum = udev_property_as_string(&d, "BUSNUM");
+        let devpath = d.devpath().and_then(OsStr::to_str);
+        device = d.parent();
+
+        let Some(busnum) = busnum else {
+            continue;
+        };
+
+        let Some(devpath) = devpath else {
+            continue;
+        };
+
+        let bus_num = u32::from_str_radix(&busnum, 10)
+            .map(|n| format!("{n:03}"))
+            .unwrap_or_default();
+
+        let port_chain = devpath
+            .rsplit_once("-")
+            .map(|s| s.1)
+            .filter(|p| *p != "0") // root hub should be empty but devpath is 0
+            .and_then(|p| {
+                p.split('.')
+                    .map(|v| v.parse::<u8>().ok())
+                    .collect::<Option<Vec<u8>>>()
+            })
+            .unwrap_or_default();
+        return (bus_num, port_chain);
+    }
+    return ("000".to_owned(), vec![]);
+}
+
 #[cfg(all(target_os = "linux", not(target_env = "musl"), feature = "libudev"))]
 fn port_type(d: &libudev::Device) -> Result<SerialPortType> {
     match d.property_value("ID_BUS").and_then(OsStr::to_str) {
@@ -123,12 +164,20 @@ fn port_type(d: &libudev::Device) -> Result<SerialPortType> {
             let product =
                 udev_property_encoded_or_replaced_as_string(d, "ID_MODEL_ENC", "ID_MODEL")
                     .or_else(|| udev_property_as_string(d, "ID_MODEL_FROM_DATABASE"));
+
+            #[cfg(feature = "port-chain")]
+            let (bus_id, port_chain) = bus_num_and_port_chain(d);
+
             Ok(SerialPortType::UsbPort(UsbPortInfo {
                 vid: udev_hex_property_as_int(d, "ID_VENDOR_ID", &u16::from_str_radix)?,
                 pid: udev_hex_property_as_int(d, "ID_MODEL_ID", &u16::from_str_radix)?,
                 serial_number,
                 manufacturer,
                 product,
+                #[cfg(feature = "port-chain")]
+                bus_id,
+                #[cfg(feature = "port-chain")]
+                port_chain,
                 #[cfg(feature = "usbportinfo-interface")]
                 interface: udev_hex_property_as_int(d, "ID_USB_INTERFACE_NUM", &u8::from_str_radix)
                     .ok(),
@@ -154,12 +203,20 @@ fn port_type(d: &libudev::Device) -> Result<SerialPortType> {
                     "ID_USB_MODEL_ENC",
                     "ID_USB_MODEL",
                 );
+
+                #[cfg(feature = "port-chain")]
+                let (bus_id, port_chain) = bus_num_and_port_chain(d);
+
                 Ok(SerialPortType::UsbPort(UsbPortInfo {
                     vid: udev_hex_property_as_int(d, "ID_USB_VENDOR_ID", &u16::from_str_radix)?,
                     pid: udev_hex_property_as_int(d, "ID_USB_MODEL_ID", &u16::from_str_radix)?,
                     serial_number: udev_property_as_string(d, "ID_USB_SERIAL_SHORT"),
                     manufacturer,
                     product,
+                    #[cfg(feature = "port-chain")]
+                    bus_id,
+                    #[cfg(feature = "port-chain")]
+                    port_chain,
                     #[cfg(feature = "usbportinfo-interface")]
                     interface: udev_hex_property_as_int(
                         d,
@@ -253,6 +310,10 @@ fn parse_modalias(moda: &str) -> Option<UsbPortInfo> {
         serial_number: None,
         manufacturer: None,
         product: None,
+        #[cfg(feature = "port-chain")]
+        bus_id: Default::default(),
+        #[cfg(feature = "port-chain")]
+        port_chain: Default::default(),
         // Only attempt to find the interface if the feature is enabled.
         #[cfg(feature = "usbportinfo-interface")]
         interface: mod_tail.get(pid_start + 4..).and_then(|mod_tail| {
@@ -617,13 +678,13 @@ cfg_if! {
             let vid = read_file_to_u16(device_path, "idVendor")?;
             let pid = read_file_to_u16(device_path, "idProduct")?;
             #[cfg(feature = "usbportinfo-interface")]
-            let interface = read_file_to_u8(&interface_path, &"bInterfaceNumber");
+            let interface = read_file_to_u8(interface_path, "bInterfaceNumber");
             let serial_number = read_file_to_trimmed_string(device_path, "serial");
             let product = read_file_to_trimmed_string(device_path, "product");
             let manufacturer = read_file_to_trimmed_string(device_path, "manufacturer");
 
             #[cfg(feature = "port-chain")]
-            let bus_id = if let Some(busnum) = read_file_to_trimmed_string(&device_path, "busnum") {
+            let bus_id = if let Some(busnum) = read_file_to_trimmed_string(device_path, "busnum") {
                 u32::from_str_radix(&busnum, 10)
                 .map(|n| format!("{n:03}"))
                 .unwrap_or_default()
@@ -632,7 +693,7 @@ cfg_if! {
             };
 
             #[cfg(feature = "port-chain")]
-            let port_chain = read_file_to_trimmed_string(&device_path, "devpath")
+            let port_chain = read_file_to_trimmed_string(device_path, "devpath")
                 .filter(|p| p != "0") // root hub should be empty but devpath is 0
                 .and_then(|p| {
                     p.split('.')

--- a/src/posix/enumerate.rs
+++ b/src/posix/enumerate.rs
@@ -46,12 +46,6 @@ use crate::UsbPortInfo;
 use crate::{Error, ErrorKind};
 use crate::{Result, SerialPortInfo};
 
-cfg_if! {
-    if #[cfg(feature = "usbportinfo-chain")] {
-        use crate::Location;
-    }
-}
-
 /// Retrieves the udev property value named by `key`. If the value exists, then it will be
 /// converted to a String, otherwise None will be returned.
 #[cfg(all(target_os = "linux", not(target_env = "musl"), feature = "libudev"))]
@@ -158,10 +152,10 @@ fn port_location(device: &libudev::Device) -> Location {
                     .collect::<Option<Vec<u8>>>()
             })
             .unwrap_or_default();
-        return Location::new(&bus_num, &port_chain);
+        return crate::Location::new(&bus_num, &port_chain);
     }
 
-    Location::new("000", &[])
+    crate::Location::new("000", &[])
 }
 
 #[cfg(all(target_os = "linux", not(target_env = "musl"), feature = "libudev"))]
@@ -451,7 +445,7 @@ fn port_type(service: io_object_t) -> SerialPortType {
             manufacturer: get_string_property(usb_device, "USB Vendor Name").ok(),
             product: get_string_property(usb_device, "USB Product Name").ok(),
             #[cfg(feature = "usbportinfo-chain")]
-            location: Location::new(
+            location: crate::Location::new(
                 &format!("{:02x}", (location_id >> 24) as u8),
                 &parse_location_id(location_id),
             ),
@@ -714,7 +708,7 @@ cfg_if! {
                     })
                     .unwrap_or_default();
 
-                Location::new(&bus_id, &port_chain)
+                crate::Location::new(&bus_id, &port_chain)
             };
 
             Some(UsbPortInfo {

--- a/src/windows/enumerate.rs
+++ b/src/windows/enumerate.rs
@@ -186,9 +186,7 @@ fn parse_usb_port_info(hardware_id: &str, parent_hardware_id: Option<&str>) -> O
         product: None,
 
         #[cfg(feature = "usbportinfo-chain")]
-        bus_id: Default::default(),
-        #[cfg(feature = "usbportinfo-chain")]
-        port_chain: Default::default(),
+        location: Default::default(),
 
         #[cfg(feature = "usbportinfo-interface")]
         interface,
@@ -196,7 +194,7 @@ fn parse_usb_port_info(hardware_id: &str, parent_hardware_id: Option<&str>) -> O
 }
 
 #[cfg(feature = "usbportinfo-chain")]
-fn parse_location_path(s: &str) -> Option<(String, Vec<u8>)> {
+fn parse_location_path(s: &str) -> Option<crate::Location> {
     let usbroot = "#USBROOT(";
     let start_i = s.find(usbroot)?;
     let close_i = s[start_i + usbroot.len()..].find(')')?;
@@ -210,7 +208,7 @@ fn parse_location_path(s: &str) -> Option<(String, Vec<u8>)> {
         s = next;
     }
 
-    Some((bus.to_owned(), path))
+    Some(crate::Location::new(bus, &path))
 }
 
 struct PortDevices {
@@ -422,13 +420,10 @@ impl PortDevice {
                 {
                     use windows_sys::Win32::Devices::DeviceAndDriverInstallation:: SPDRP_LOCATION_PATHS;
                     let location_paths = self.property_list(SPDRP_LOCATION_PATHS);
-                    eprintln!("Location paths: {location_paths:?}");
-                    let (bus_id, port_chain) = location_paths
+                    info.location = location_paths
                         .iter()
                         .find_map(|p| parse_location_path(p))
                         .unwrap_or_default();
-                    info.bus_id = bus_id;
-                    info.port_chain = port_chain;
                 }
 
                 SerialPortType::UsbPort(info)

--- a/src/windows/enumerate.rs
+++ b/src/windows/enumerate.rs
@@ -185,9 +185,9 @@ fn parse_usb_port_info(hardware_id: &str, parent_hardware_id: Option<&str>) -> O
         manufacturer: None,
         product: None,
 
-        #[cfg(feature = "port-chain")]
+        #[cfg(feature = "usbportinfo-chain")]
         bus_id: Default::default(),
-        #[cfg(feature = "port-chain")]
+        #[cfg(feature = "usbportinfo-chain")]
         port_chain: Default::default(),
 
         #[cfg(feature = "usbportinfo-interface")]
@@ -195,7 +195,7 @@ fn parse_usb_port_info(hardware_id: &str, parent_hardware_id: Option<&str>) -> O
     })
 }
 
-#[cfg(feature = "port-chain")]
+#[cfg(feature = "usbportinfo-chain")]
 fn parse_location_path(s: &str) -> Option<(String, Vec<u8>)> {
     let usbroot = "#USBROOT(";
     let start_i = s.find(usbroot)?;
@@ -418,7 +418,7 @@ impl PortDevice {
                 info.manufacturer = self.property(SPDRP_MFG);
                 info.product = self.property(SPDRP_FRIENDLYNAME);
 
-                #[cfg(feature = "port-chain")]
+                #[cfg(feature = "usbportinfo-chain")]
                 {
                     use windows_sys::Win32::Devices::DeviceAndDriverInstallation:: SPDRP_LOCATION_PATHS;
                     let location_paths = self.property_list(SPDRP_LOCATION_PATHS);
@@ -469,7 +469,7 @@ impl PortDevice {
 
     // Retrieves a device property and returns it, if it exists. Returns None if the property
     // doesn't exist.
-    #[cfg(feature = "port-chain")]
+    #[cfg(feature = "usbportinfo-chain")]
     fn property_list(&mut self, property_id: u32) -> Vec<String> {
         use windows_sys::Win32::System::Registry::REG_MULTI_SZ;
         let mut value_type = 0;

--- a/src/windows/enumerate.rs
+++ b/src/windows/enumerate.rs
@@ -7,12 +7,12 @@ use windows_sys::Win32::Devices::DeviceAndDriverInstallation::{
     SetupDiDestroyDeviceInfoList, SetupDiEnumDeviceInfo, SetupDiGetClassDevsW,
     SetupDiGetDeviceInstanceIdW, SetupDiGetDeviceRegistryPropertyW, SetupDiOpenDevRegKey,
     CR_SUCCESS, DICS_FLAG_GLOBAL, DIGCF_PRESENT, DIREG_DEV, HDEVINFO, MAX_DEVICE_ID_LEN,
-    SPDRP_FRIENDLYNAME, SPDRP_HARDWAREID, SPDRP_MFG, SP_DEVINFO_DATA,
+    SPDRP_FRIENDLYNAME, SPDRP_HARDWAREID, SPDRP_LOCATION_PATHS, SPDRP_MFG, SP_DEVINFO_DATA,
 };
 use windows_sys::Win32::Foundation::{FALSE, FILETIME, INVALID_HANDLE_VALUE, MAX_PATH};
 use windows_sys::Win32::System::Registry::{
     RegCloseKey, RegEnumValueW, RegOpenKeyExW, RegQueryInfoKeyW, RegQueryValueExW, HKEY,
-    HKEY_LOCAL_MACHINE, KEY_READ, REG_SZ,
+    HKEY_LOCAL_MACHINE, KEY_READ, REG_MULTI_SZ, REG_SZ,
 };
 
 use crate::{Error, ErrorKind, Result, SerialPortInfo, SerialPortType, UsbPortInfo};
@@ -185,9 +185,32 @@ fn parse_usb_port_info(hardware_id: &str, parent_hardware_id: Option<&str>) -> O
         manufacturer: None,
         product: None,
 
+        #[cfg(feature = "port-chain")]
+        bus_id: Default::default(),
+        #[cfg(feature = "port-chain")]
+        port_chain: Default::default(),
+
         #[cfg(feature = "usbportinfo-interface")]
         interface,
     })
+}
+
+#[cfg(feature = "port-chain")]
+fn parse_location_path(s: &str) -> Option<(String, Vec<u8>)> {
+    let usbroot = "#USBROOT(";
+    let start_i = s.find(usbroot)?;
+    let close_i = s[start_i + usbroot.len()..].find(')')?;
+    let (bus, mut s) = s.split_at(start_i + usbroot.len() + close_i + 1);
+
+    let mut path = vec![];
+
+    while let Some((_, next)) = s.split_once("#USB(") {
+        let (port_num, next) = next.split_once(")")?;
+        path.push(port_num.parse().ok()?);
+        s = next;
+    }
+
+    Some((bus.to_owned(), path))
 }
 
 struct PortDevices {
@@ -394,6 +417,19 @@ impl PortDevice {
             .map(|mut info: UsbPortInfo| {
                 info.manufacturer = self.property(SPDRP_MFG);
                 info.product = self.property(SPDRP_FRIENDLYNAME);
+
+                #[cfg(feature = "port-chain")]
+                {
+                    let location_paths = self.property_list(SPDRP_LOCATION_PATHS);
+                    eprintln!("Location paths: {location_paths:?}");
+                    let (bus_id, port_chain) = location_paths
+                        .iter()
+                        .find_map(|p| parse_location_path(p))
+                        .unwrap_or_default();
+                    info.bus_id = bus_id;
+                    info.port_chain = port_chain;
+                }
+
                 SerialPortType::UsbPort(info)
             })
             .unwrap_or(SerialPortType::Unknown)
@@ -428,6 +464,39 @@ impl PortDevice {
             .split(';')
             .next_back()
             .map(str::to_string)
+    }
+
+    // Retrieves a device property and returns it, if it exists. Returns None if the property
+    // doesn't exist.
+    fn property_list(&mut self, property_id: u32) -> Vec<String> {
+        let mut value_type = 0;
+        let mut property_buf = [0u16; MAX_PATH as usize];
+
+        let res = unsafe {
+            SetupDiGetDeviceRegistryPropertyW(
+                self.hdi,
+                &self.devinfo_data,
+                property_id,
+                &mut value_type,
+                property_buf.as_mut_ptr() as *mut u8,
+                property_buf.len() as u32,
+                ptr::null_mut(),
+            )
+        };
+
+        if res == FALSE || value_type != REG_MULTI_SZ {
+            return vec![];
+        }
+
+        let mut out = vec![];
+        for chunk in property_buf.split(|c| *c == 0) {
+            // A NULL value indicates the end of the list
+            if chunk.len() == 0 {
+                break;
+            }
+            out.push(from_utf16_lossy_trimmed(chunk));
+        }
+        out
     }
 }
 

--- a/src/windows/enumerate.rs
+++ b/src/windows/enumerate.rs
@@ -7,12 +7,12 @@ use windows_sys::Win32::Devices::DeviceAndDriverInstallation::{
     SetupDiDestroyDeviceInfoList, SetupDiEnumDeviceInfo, SetupDiGetClassDevsW,
     SetupDiGetDeviceInstanceIdW, SetupDiGetDeviceRegistryPropertyW, SetupDiOpenDevRegKey,
     CR_SUCCESS, DICS_FLAG_GLOBAL, DIGCF_PRESENT, DIREG_DEV, HDEVINFO, MAX_DEVICE_ID_LEN,
-    SPDRP_FRIENDLYNAME, SPDRP_HARDWAREID, SPDRP_LOCATION_PATHS, SPDRP_MFG, SP_DEVINFO_DATA,
+    SPDRP_FRIENDLYNAME, SPDRP_HARDWAREID, SPDRP_MFG, SP_DEVINFO_DATA,
 };
 use windows_sys::Win32::Foundation::{FALSE, FILETIME, INVALID_HANDLE_VALUE, MAX_PATH};
 use windows_sys::Win32::System::Registry::{
     RegCloseKey, RegEnumValueW, RegOpenKeyExW, RegQueryInfoKeyW, RegQueryValueExW, HKEY,
-    HKEY_LOCAL_MACHINE, KEY_READ, REG_MULTI_SZ, REG_SZ,
+    HKEY_LOCAL_MACHINE, KEY_READ, REG_SZ,
 };
 
 use crate::{Error, ErrorKind, Result, SerialPortInfo, SerialPortType, UsbPortInfo};
@@ -420,6 +420,7 @@ impl PortDevice {
 
                 #[cfg(feature = "port-chain")]
                 {
+                    use windows_sys::Win32::Devices::DeviceAndDriverInstallation:: SPDRP_LOCATION_PATHS;
                     let location_paths = self.property_list(SPDRP_LOCATION_PATHS);
                     eprintln!("Location paths: {location_paths:?}");
                     let (bus_id, port_chain) = location_paths
@@ -468,7 +469,9 @@ impl PortDevice {
 
     // Retrieves a device property and returns it, if it exists. Returns None if the property
     // doesn't exist.
+    #[cfg(feature = "port-chain")]
     fn property_list(&mut self, property_id: u32) -> Vec<String> {
+        use windows_sys::Win32::System::Registry::REG_MULTI_SZ;
         let mut value_type = 0;
         let mut property_buf = [0u16; MAX_PATH as usize];
 
@@ -491,7 +494,7 @@ impl PortDevice {
         let mut out = vec![];
         for chunk in property_buf.split(|c| *c == 0) {
             // A NULL value indicates the end of the list
-            if chunk.len() == 0 {
+            if chunk.is_empty() {
                 break;
             }
             out.push(from_utf16_lossy_trimmed(chunk));

--- a/src/windows/enumerate.rs
+++ b/src/windows/enumerate.rs
@@ -185,7 +185,7 @@ fn parse_usb_port_info(hardware_id: &str, parent_hardware_id: Option<&str>) -> O
         manufacturer: None,
         product: None,
 
-        #[cfg(feature = "usbportinfo-chain")]
+        #[cfg(feature = "usbportinfo-location")]
         location: Default::default(),
 
         #[cfg(feature = "usbportinfo-interface")]
@@ -193,7 +193,7 @@ fn parse_usb_port_info(hardware_id: &str, parent_hardware_id: Option<&str>) -> O
     })
 }
 
-#[cfg(feature = "usbportinfo-chain")]
+#[cfg(feature = "usbportinfo-location")]
 fn parse_location_path(s: &str) -> Option<crate::Location> {
     let usbroot = "#USBROOT(";
     let start_i = s.find(usbroot)?;
@@ -416,7 +416,7 @@ impl PortDevice {
                 info.manufacturer = self.property(SPDRP_MFG);
                 info.product = self.property(SPDRP_FRIENDLYNAME);
 
-                #[cfg(feature = "usbportinfo-chain")]
+                #[cfg(feature = "usbportinfo-location")]
                 {
                     use windows_sys::Win32::Devices::DeviceAndDriverInstallation:: SPDRP_LOCATION_PATHS;
                     let location_paths = self.property_list(SPDRP_LOCATION_PATHS);
@@ -464,7 +464,7 @@ impl PortDevice {
 
     // Retrieves a device property and returns it, if it exists. Returns None if the property
     // doesn't exist.
-    #[cfg(feature = "usbportinfo-chain")]
+    #[cfg(feature = "usbportinfo-location")]
     fn property_list(&mut self, property_id: u32) -> Vec<String> {
         use windows_sys::Win32::System::Registry::REG_MULTI_SZ;
         let mut value_type = 0;


### PR DESCRIPTION
Add a feature to list a USB port's chain. This gives a unique value to the port, and allows for differentiating between different serial ports that may share the same VID/PID/Serial.

The approach is mostly taken from the nusb project, with adjustments made to adapt it to the serialport way of doing things.

This closes #222.