### PR TITLE
Update to nix 0.31

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -234,7 +234,6 @@ jobs:
   aarch64-apple-darwin:
     uses: ./.github/workflows/build.yaml
     with:
-      disable_tests: true
       runs_on: macos-latest
       target: aarch64-apple-darwin
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["hardware-support"]
 
 [target."cfg(unix)".dependencies]
 bitflags = "2.4.0"
-nix = { version = "0.29", default-features = false, features = ["fs", "ioctl", "poll", "signal", "term"] }
+nix = { version = "0.30", default-features = false, features = ["fs", "ioctl", "poll", "signal", "term"] }
 
 [target.'cfg(all(target_os = "linux", not(target_env = "musl")))'.dependencies]
 libudev = { version = "0.3.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["hardware-support"]
 
 [target."cfg(unix)".dependencies]
 bitflags = "2.4.0"
-nix = { version = "0.28", default-features = false, features = ["fs", "ioctl", "poll", "signal", "term"] }
+nix = { version = "0.29", default-features = false, features = ["fs", "ioctl", "poll", "signal", "term"] }
 
 [target.'cfg(all(target_os = "linux", not(target_env = "musl")))'.dependencies]
 libudev = { version = "0.3.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["hardware-support"]
 
 [target."cfg(unix)".dependencies]
 bitflags = "2.4.0"
-nix = { version = "0.26", default-features = false, features = ["fs", "ioctl", "poll", "signal", "term"] }
+nix = { version = "0.27", default-features = false, features = ["fs", "ioctl", "poll", "signal", "term"] }
 
 [target.'cfg(all(target_os = "linux", not(target_env = "musl")))'.dependencies]
 libudev = { version = "0.3.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["hardware-support"]
 
 [target."cfg(unix)".dependencies]
 bitflags = "2.4.0"
-nix = { version = "0.27", default-features = false, features = ["fs", "ioctl", "poll", "signal", "term"] }
+nix = { version = "0.28", default-features = false, features = ["fs", "ioctl", "poll", "signal", "term"] }
 
 [target.'cfg(all(target_os = "linux", not(target_env = "musl")))'.dependencies]
 libudev = { version = "0.3.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["hardware-support"]
 
 [target."cfg(unix)".dependencies]
 bitflags = "2.4.0"
-nix = { version = "0.30", default-features = false, features = ["fs", "ioctl", "poll", "signal", "term"] }
+nix = { version = "0.31.3", default-features = false, features = ["fs", "ioctl", "poll", "signal", "term"] }
 
 [target.'cfg(all(target_os = "linux", not(target_env = "musl")))'.dependencies]
 libudev = { version = "0.3.0", optional = true }

--- a/src/posix/flock.rs
+++ b/src/posix/flock.rs
@@ -1,24 +1,18 @@
 //! Internal convenience wrappers for using `flock`.
 
 use crate::{Error, ErrorKind, Result};
-use nix::fcntl::FlockArg;
+use nix::{
+    errno::Errno,
+    fcntl::{Flock, FlockArg},
+};
 use std::os::unix::prelude::*;
 
 /// Convenience method to acquire an exclusive lock using flock
 ///
 /// This is used ensure that no other applications are using the port. This requires that the other
 /// application also uses flock, so this does not work with all applications.
-pub(crate) fn lock_exclusive(fd: RawFd) -> Result<()> {
-    nix::fcntl::flock(fd, FlockArg::LockExclusiveNonblock).map_err(|e| {
-        if e == nix::errno::Errno::EWOULDBLOCK {
-            Error::new(
-                ErrorKind::NoDevice,
-                "Unable to acquire exclusive lock on serial port",
-            )
-        } else {
-            e.into()
-        }
-    })
+pub fn lock_exclusive(fd: OwnedFd) -> Result<Flock<OwnedFd>> {
+    Flock::lock(fd, FlockArg::LockExclusiveNonblock).map_err(|(_, e)| convert_exclusive_error(e))
 }
 
 /// Convenience method to acquire a shared lock using flock
@@ -26,15 +20,40 @@ pub(crate) fn lock_exclusive(fd: RawFd) -> Result<()> {
 /// With the shared lock, other applications are able to use the port as well, if they're also
 /// using a shared lock, but this makes sure that they cannot acquire an exclusive lock while we're
 /// using the port.
-pub(crate) fn lock_shared(fd: RawFd) -> Result<()> {
-    nix::fcntl::flock(fd, FlockArg::LockSharedNonblock).map_err(|e| {
-        if e == nix::errno::Errno::EWOULDBLOCK {
-            Error::new(
-                ErrorKind::NoDevice,
-                "Unable to acquire shared lock on serial port",
-            )
-        } else {
-            e.into()
-        }
-    })
+pub fn lock_shared(fd: OwnedFd) -> Result<Flock<OwnedFd>> {
+    Flock::lock(fd, FlockArg::LockSharedNonblock).map_err(|(_, e)| convert_shared_error(e))
+}
+
+/// Changes the flock to an exclusive lock.
+pub fn relock_exclusive(fd: &Flock<OwnedFd>) -> Result<()> {
+    fd.relock(FlockArg::LockExclusiveNonblock)
+        .map_err(convert_exclusive_error)
+}
+
+/// Changes the flock to a shared lock.
+pub fn relock_shared(fd: &Flock<OwnedFd>) -> Result<()> {
+    fd.relock(FlockArg::LockSharedNonblock)
+        .map_err(convert_exclusive_error)
+}
+
+fn convert_exclusive_error(e: Errno) -> Error {
+    if e == Errno::EWOULDBLOCK {
+        Error::new(
+            ErrorKind::NoDevice,
+            "Unable to acquire exclusive lock on serial port",
+        )
+    } else {
+        e.into()
+    }
+}
+
+fn convert_shared_error(e: Errno) -> Error {
+    if e == Errno::EWOULDBLOCK {
+        Error::new(
+            ErrorKind::NoDevice,
+            "Unable to acquire shared lock on serial port",
+        )
+    } else {
+        e.into()
+    }
 }

--- a/src/posix/flock.rs
+++ b/src/posix/flock.rs
@@ -1,10 +1,8 @@
 //! Internal convenience wrappers for using `flock`.
 
 use crate::{Error, ErrorKind, Result};
-use nix::{
-    errno::Errno,
-    fcntl::{Flock, FlockArg},
-};
+use nix::errno::Errno;
+use nix::fcntl::{Flock, FlockArg};
 use std::os::unix::prelude::*;
 
 /// Convenience method to acquire an exclusive lock using flock

--- a/src/posix/poll.rs
+++ b/src/posix/poll.rs
@@ -23,8 +23,7 @@ pub fn wait_write_fd<Fd: AsFd>(fd: Fd, timeout: Duration) -> io::Result<()> {
 fn wait_fd<Fd: AsFd>(fd: Fd, events: PollFlags, timeout: Duration) -> io::Result<()> {
     use nix::errno::Errno::{EIO, EPIPE};
 
-    let fd = fd.as_fd();
-    let mut fd = PollFd::new(&fd, events);
+    let mut fd = PollFd::new(fd.as_fd(), events);
 
     let wait = match poll_clamped(&mut fd, timeout) {
         Ok(r) => r,
@@ -87,44 +86,39 @@ fn clamped_time_spec(duration: Duration) -> TimeSpec {
 // by `poll`.
 #[cfg(not(target_os = "linux"))]
 fn poll_clamped(fd: &mut PollFd, timeout: Duration) -> nix::Result<c_int> {
-    let millis = clamped_millis_c_int(timeout);
+    let millis = clamped_duration_nix(timeout);
     nix::poll::poll(slice::from_mut(fd), millis)
 }
 
 #[cfg(any(not(target_os = "linux"), test))]
-fn clamped_millis_c_int(duration: Duration) -> c_int {
-    let secs_limit = (c_int::MAX as u64) / 1000;
-    let secs = duration.as_secs();
-
-    if secs <= secs_limit {
-        secs as c_int * 1000 + duration.subsec_millis() as c_int
-    } else {
-        c_int::MAX
-    }
+fn clamped_duration_nix(duration: Duration) -> nix::poll::PollTimeout {
+    nix::poll::PollTimeout::try_from(duration).unwrap_or(nix::poll::PollTimeout::MAX)
 }
 
 #[cfg(test)]
 mod tests {
+    use nix::poll::PollTimeout;
+
     use super::*;
     use crate::tests::timeout::MONOTONIC_DURATIONS;
 
     #[test]
-    fn clamped_millis_c_int_is_monotonic() {
-        let mut last = clamped_millis_c_int(Duration::ZERO);
+    fn clamped_duration_nix_is_monotonic() {
+        let mut last = clamped_duration_nix(Duration::ZERO);
 
         for (i, d) in MONOTONIC_DURATIONS.iter().enumerate() {
-            let next = clamped_millis_c_int(*d);
+            let next = clamped_duration_nix(*d);
             assert!(
                 next >= last,
-                "{next} >= {last} failed for {d:?} at index {i}"
+                "{next:?} >= {last:?} failed for {d:?} at index {i}"
             );
             last = next;
         }
     }
 
     #[test]
-    fn clamped_millis_c_int_zero_is_zero() {
-        assert_eq!(0, clamped_millis_c_int(Duration::ZERO));
+    fn clamped_duration_nix_zero_is_zero() {
+        assert_eq!(PollTimeout::ZERO, clamped_duration_nix(Duration::ZERO));
     }
 
     #[test]

--- a/src/posix/poll.rs
+++ b/src/posix/poll.rs
@@ -1,7 +1,7 @@
 #![allow(non_camel_case_types, dead_code)]
 
 use std::io;
-use std::os::unix::io::RawFd;
+use std::os::fd::AsFd;
 use std::slice;
 use std::time::Duration;
 
@@ -12,18 +12,19 @@ use nix::sys::signal::SigSet;
 #[cfg(any(target_os = "linux", test))]
 use nix::sys::time::TimeSpec;
 
-pub fn wait_read_fd(fd: RawFd, timeout: Duration) -> io::Result<()> {
-    wait_fd(fd, PollFlags::POLLIN, timeout)
+pub fn wait_read_fd<Fd: AsFd>(fd: Fd, timeout: Duration) -> io::Result<()> {
+    wait_fd(fd.as_fd(), PollFlags::POLLIN, timeout)
 }
 
-pub fn wait_write_fd(fd: RawFd, timeout: Duration) -> io::Result<()> {
-    wait_fd(fd, PollFlags::POLLOUT, timeout)
+pub fn wait_write_fd<Fd: AsFd>(fd: Fd, timeout: Duration) -> io::Result<()> {
+    wait_fd(fd.as_fd(), PollFlags::POLLOUT, timeout)
 }
 
-fn wait_fd(fd: RawFd, events: PollFlags, timeout: Duration) -> io::Result<()> {
+fn wait_fd<Fd: AsFd>(fd: Fd, events: PollFlags, timeout: Duration) -> io::Result<()> {
     use nix::errno::Errno::{EIO, EPIPE};
 
-    let mut fd = PollFd::new(fd, events);
+    let fd = fd.as_fd();
+    let mut fd = PollFd::new(&fd, events);
 
     let wait = match poll_clamped(&mut fd, timeout) {
         Ok(r) => r,

--- a/src/posix/poll.rs
+++ b/src/posix/poll.rs
@@ -13,11 +13,11 @@ use nix::sys::signal::SigSet;
 use nix::sys::time::TimeSpec;
 
 pub fn wait_read_fd<Fd: AsFd>(fd: Fd, timeout: Duration) -> io::Result<()> {
-    wait_fd(fd.as_fd(), PollFlags::POLLIN, timeout)
+    wait_fd(fd, PollFlags::POLLIN, timeout)
 }
 
 pub fn wait_write_fd<Fd: AsFd>(fd: Fd, timeout: Duration) -> io::Result<()> {
-    wait_fd(fd.as_fd(), PollFlags::POLLOUT, timeout)
+    wait_fd(fd, PollFlags::POLLOUT, timeout)
 }
 
 fn wait_fd<Fd: AsFd>(fd: Fd, events: PollFlags, timeout: Duration) -> io::Result<()> {

--- a/src/posix/tty.rs
+++ b/src/posix/tty.rs
@@ -109,7 +109,6 @@ impl TTYPort {
             OFlag::O_RDWR | OFlag::O_NOCTTY | OFlag::O_NONBLOCK | OFlag::O_CLOEXEC,
             nix::sys::stat::Mode::empty(),
         )?;
-        let fd = unsafe { OwnedFd::from_raw_fd(fd) };
 
         // Set the requested access mode on the port. In exclusive mode use
         // TIOCEXCL and an exclusive flock to prevent other openers. In shared
@@ -157,10 +156,7 @@ impl TTYPort {
         }
 
         // clear O_NONBLOCK flag
-        fcntl(
-            fd.as_raw_fd(),
-            FcntlArg::F_SETFL(nix::fcntl::OFlag::empty()),
-        )?;
+        fcntl(&fd, FcntlArg::F_SETFL(nix::fcntl::OFlag::empty()))?;
 
         // Configure the low-level port settings
         let mut termios = termios::get_termios(fd.as_raw_fd())?;
@@ -311,8 +307,6 @@ impl TTYPort {
             OFlag::O_RDWR | OFlag::O_NOCTTY | OFlag::O_NONBLOCK,
             nix::sys::stat::Mode::empty(),
         )?;
-        // Wrap the slave fd in `OwnedFd` immediately so it auto-closes on error
-        let fd = unsafe { OwnedFd::from_raw_fd(fd) };
 
         // Set the port to a raw state. Using these ports will not work without this.
         let mut termios = MaybeUninit::uninit();
@@ -323,7 +317,7 @@ impl TTYPort {
         Errno::result(unsafe { libc::tcsetattr(fd.as_raw_fd(), libc::TCSANOW, &termios) })?;
 
         fcntl(
-            fd.as_raw_fd(),
+            &fd,
             nix::fcntl::FcntlArg::F_SETFL(nix::fcntl::OFlag::empty()),
         )?;
 
@@ -354,8 +348,8 @@ impl TTYPort {
     /// Sends 0-valued bits over the port for a set duration
     pub fn send_break(&self, duration: BreakDuration) -> Result<()> {
         match duration {
-            BreakDuration::Short => nix::sys::termios::tcsendbreak(self.fd.as_fd(), 0),
-            BreakDuration::Arbitrary(n) => nix::sys::termios::tcsendbreak(self.fd.as_fd(), n.get()),
+            BreakDuration::Short => nix::sys::termios::tcsendbreak(&self.fd, 0),
+            BreakDuration::Arbitrary(n) => nix::sys::termios::tcsendbreak(&self.fd, n.get()),
         }
         .map_err(|e| e.into())
     }
@@ -375,10 +369,7 @@ impl TTYPort {
     ///
     /// This function returns an error if the serial port couldn't be cloned.
     pub fn try_clone_native(&self) -> Result<TTYPort> {
-        let fd_cloned: i32 = fcntl(
-            self.fd.as_raw_fd(),
-            nix::fcntl::F_DUPFD_CLOEXEC(self.fd.as_raw_fd()),
-        )?;
+        let fd_cloned: i32 = fcntl(&self.fd, nix::fcntl::F_DUPFD_CLOEXEC(self.fd.as_raw_fd()))?;
         Ok(TTYPort {
             fd: unsafe { OwnedFd::from_raw_fd(fd_cloned) },
             exclusive: self.exclusive,
@@ -448,7 +439,7 @@ impl io::Read for TTYPort {
             return Err(io::Error::from(Error::from(e)));
         }
 
-        nix::unistd::read(self.fd.as_raw_fd(), buf).map_err(|e| io::Error::from(Error::from(e)))
+        nix::unistd::read(&self.fd, buf).map_err(|e| io::Error::from(Error::from(e)))
     }
 }
 
@@ -458,13 +449,13 @@ impl io::Write for TTYPort {
             return Err(io::Error::from(Error::from(e)));
         }
 
-        nix::unistd::write(self.fd.as_fd(), buf).map_err(|e| io::Error::from(Error::from(e)))
+        nix::unistd::write(&self.fd, buf).map_err(|e| io::Error::from(Error::from(e)))
     }
 
     fn flush(&mut self) -> io::Result<()> {
         let timeout = Instant::now() + self.timeout;
         loop {
-            return match nix::sys::termios::tcdrain(self.fd.as_fd()) {
+            return match nix::sys::termios::tcdrain(&self.fd) {
                 Ok(_) => Ok(()),
                 Err(Errno::EINTR) => {
                     // Retry flushing. But only up to the ports timeout for not retrying

--- a/src/posix/tty.rs
+++ b/src/posix/tty.rs
@@ -273,13 +273,13 @@ impl TTYPort {
     /// ```
     pub fn pair() -> Result<(Self, Self)> {
         // Open the next free pty.
-        let next_pty_fd = nix::pty::posix_openpt(nix::fcntl::OFlag::O_RDWR)?;
+        let master = nix::pty::posix_openpt(nix::fcntl::OFlag::O_RDWR)?;
 
         // Grant access to the associated slave pty
-        nix::pty::grantpt(&next_pty_fd)?;
+        nix::pty::grantpt(&master)?;
 
         // Unlock the slave pty
-        nix::pty::unlockpt(&next_pty_fd)?;
+        nix::pty::unlockpt(&master)?;
 
         // Get the path of the attached slave ptty
         #[cfg(not(any(
@@ -288,7 +288,7 @@ impl TTYPort {
             target_os = "emscripten",
             target_os = "fuchsia"
         )))]
-        let ptty_name = unsafe { nix::pty::ptsname(&next_pty_fd)? };
+        let ptty_name = unsafe { nix::pty::ptsname(&master)? };
 
         #[cfg(any(
             target_os = "linux",
@@ -296,13 +296,13 @@ impl TTYPort {
             target_os = "emscripten",
             target_os = "fuchsia"
         ))]
-        let ptty_name = nix::pty::ptsname_r(&next_pty_fd)?;
+        let ptty_name = nix::pty::ptsname_r(&master)?;
 
         // Open the slave port
         #[cfg(any(target_os = "ios", target_os = "macos"))]
         let baud_rate = 9600;
 
-        let fd = nix::fcntl::open(
+        let slave_fd = nix::fcntl::open(
             Path::new(&ptty_name),
             OFlag::O_RDWR | OFlag::O_NOCTTY | OFlag::O_NONBLOCK,
             nix::sys::stat::Mode::empty(),
@@ -310,20 +310,20 @@ impl TTYPort {
 
         // Set the port to a raw state. Using these ports will not work without this.
         let mut termios = MaybeUninit::uninit();
-        Errno::result(unsafe { libc::tcgetattr(fd.as_raw_fd(), termios.as_mut_ptr()) })?;
+        Errno::result(unsafe { libc::tcgetattr(slave_fd.as_raw_fd(), termios.as_mut_ptr()) })?;
 
         let mut termios = unsafe { termios.assume_init() };
         unsafe { libc::cfmakeraw(&mut termios) };
-        Errno::result(unsafe { libc::tcsetattr(fd.as_raw_fd(), libc::TCSANOW, &termios) })?;
+        Errno::result(unsafe { libc::tcsetattr(slave_fd.as_raw_fd(), libc::TCSANOW, &termios) })?;
 
         fcntl(
-            &fd,
+            &slave_fd,
             nix::fcntl::FcntlArg::F_SETFL(nix::fcntl::OFlag::empty()),
         )?;
 
-        let fd = flock::lock_exclusive(fd)?;
+        let slave_fd = flock::lock_exclusive(slave_fd)?;
         let slave_tty = TTYPort {
-            fd,
+            fd: slave_fd,
             timeout: Duration::from_millis(100),
             exclusive: true,
             port_name: Some(ptty_name),
@@ -331,7 +331,7 @@ impl TTYPort {
             baud_rate,
         };
 
-        let master_fd = unsafe { OwnedFd::from_raw_fd(next_pty_fd.into_raw_fd()) };
+        let master_fd = master.into();
         let master_fd = flock::lock_exclusive(master_fd)?;
         // Manually construct the master port here because the
         // `tcgetattr()` doesn't work on Mac, Solaris, and maybe other

--- a/src/posix/tty.rs
+++ b/src/posix/tty.rs
@@ -458,7 +458,7 @@ impl io::Write for TTYPort {
             return Err(io::Error::from(Error::from(e)));
         }
 
-        nix::unistd::write(self.fd.as_raw_fd(), buf).map_err(|e| io::Error::from(Error::from(e)))
+        nix::unistd::write(self.fd.as_fd(), buf).map_err(|e| io::Error::from(Error::from(e)))
     }
 
     fn flush(&mut self) -> io::Result<()> {

--- a/src/posix/tty.rs
+++ b/src/posix/tty.rs
@@ -1,12 +1,13 @@
+use std::io;
 use std::mem::MaybeUninit;
+use std::os::fd::OwnedFd;
 use std::os::unix::prelude::*;
 use std::path::Path;
 use std::time::{Duration, Instant};
-use std::{io, mem};
 
 use nix::errno::Errno;
 use nix::fcntl::{fcntl, FcntlArg, OFlag};
-use nix::{libc, unistd};
+use nix::libc;
 
 use crate::posix::flock;
 use crate::posix::ioctl::{self, SerialLines};
@@ -18,6 +19,7 @@ use crate::{
 
 /// Convenience method for removing exclusive access from
 /// a fd and closing it.
+#[cfg(test)]
 fn close(fd: RawFd) {
     // Remove exclusive access on best-effort. There is no documentation hinting at `TIOCEXCL`
     // being cleared automatically so explicitly attempt it here.
@@ -34,7 +36,7 @@ fn close(fd: RawFd) {
     //
     // close() also should never be retried, and the error code
     // in most cases in purely informative
-    let _ = unistd::close(fd);
+    let _ = nix::unistd::close(fd);
 }
 
 /// A serial port implementation for POSIX TTY ports
@@ -65,7 +67,7 @@ fn close(fd: RawFd) {
 /// ```
 #[derive(Debug)]
 pub struct TTYPort {
-    fd: RawFd,
+    fd: OwnedFd,
     timeout: Duration,
     exclusive: bool,
     port_name: Option<String>,
@@ -80,26 +82,6 @@ pub enum BreakDuration {
     Short,
     /// Specifies a break duration that is platform-dependent
     Arbitrary(std::num::NonZeroI32),
-}
-
-/// Wrapper for RawFd to assure that it's properly closed,
-/// even if the enclosing function exits early.
-///
-/// This is similar to the (nightly-only) std::os::unix::io::OwnedFd.
-struct OwnedFd(RawFd);
-
-impl Drop for OwnedFd {
-    fn drop(&mut self) {
-        close(self.0);
-    }
-}
-
-impl OwnedFd {
-    fn into_raw_fd(self) -> RawFd {
-        let fd = self.0;
-        mem::forget(self);
-        fd
-    }
 }
 
 impl TTYPort {
@@ -122,23 +104,24 @@ impl TTYPort {
     /// * `Io` for any other error while opening or initializing the device.
     pub fn open(builder: &SerialPortBuilder) -> Result<TTYPort> {
         let path = Path::new(&builder.path);
-        let fd = OwnedFd(nix::fcntl::open(
+        let fd = nix::fcntl::open(
             path,
             OFlag::O_RDWR | OFlag::O_NOCTTY | OFlag::O_NONBLOCK | OFlag::O_CLOEXEC,
             nix::sys::stat::Mode::empty(),
-        )?);
+        )?;
+        let fd = unsafe { OwnedFd::from_raw_fd(fd) };
 
         // Set the requested access mode on the port. In exclusive mode use
         // TIOCEXCL and an exclusive flock to prevent other openers. In shared
         // mode we only need a shared flock to allow concurrent access.
         if builder.exclusive {
-            ioctl::tiocexcl(fd.0)?;
-            flock::lock_exclusive(fd.0)?;
+            ioctl::tiocexcl(fd.as_raw_fd())?;
+            flock::lock_exclusive(fd.as_raw_fd())?;
         } else {
-            flock::lock_shared(fd.0)?;
+            flock::lock_shared(fd.as_raw_fd())?;
         }
         let mut termios = MaybeUninit::uninit();
-        Errno::result(unsafe { libc::tcgetattr(fd.0, termios.as_mut_ptr()) })?;
+        Errno::result(unsafe { libc::tcgetattr(fd.as_raw_fd(), termios.as_mut_ptr()) })?;
         let mut termios = unsafe { termios.assume_init() };
 
         // setup TTY for binary serial port access
@@ -150,11 +133,11 @@ impl TTYPort {
         unsafe { libc::cfmakeraw(&mut termios) };
 
         // write settings to TTY
-        Errno::result(unsafe { libc::tcsetattr(fd.0, libc::TCSANOW, &termios) })?;
+        Errno::result(unsafe { libc::tcsetattr(fd.as_raw_fd(), libc::TCSANOW, &termios) })?;
 
         // Read back settings from port and confirm they were applied correctly
         let mut actual_termios = MaybeUninit::uninit();
-        Errno::result(unsafe { libc::tcgetattr(fd.0, actual_termios.as_mut_ptr()) })?;
+        Errno::result(unsafe { libc::tcgetattr(fd.as_raw_fd(), actual_termios.as_mut_ptr()) })?;
         let actual_termios = unsafe { actual_termios.assume_init() };
 
         if actual_termios.c_iflag != termios.c_iflag
@@ -170,14 +153,17 @@ impl TTYPort {
 
         #[cfg(any(target_os = "ios", target_os = "macos"))]
         if builder.baud_rate > 0 {
-            Errno::result(unsafe { libc::tcflush(fd.0, libc::TCIOFLUSH) })?;
+            Errno::result(unsafe { libc::tcflush(fd.as_raw_fd(), libc::TCIOFLUSH) })?;
         }
 
         // clear O_NONBLOCK flag
-        fcntl(fd.0, FcntlArg::F_SETFL(nix::fcntl::OFlag::empty()))?;
+        fcntl(
+            fd.as_raw_fd(),
+            FcntlArg::F_SETFL(nix::fcntl::OFlag::empty()),
+        )?;
 
         // Configure the low-level port settings
-        let mut termios = termios::get_termios(fd.0)?;
+        let mut termios = termios::get_termios(fd.as_raw_fd())?;
         termios::set_parity(&mut termios, builder.parity);
         termios::set_flow_control(&mut termios, builder.flow_control);
         termios::set_data_bits(&mut termios, builder.data_bits);
@@ -185,13 +171,13 @@ impl TTYPort {
         #[cfg(not(any(target_os = "ios", target_os = "macos")))]
         termios::set_baud_rate(&mut termios, builder.baud_rate)?;
         #[cfg(any(target_os = "ios", target_os = "macos"))]
-        termios::set_termios(fd.0, &termios, builder.baud_rate)?;
+        termios::set_termios(fd.as_raw_fd(), &termios, builder.baud_rate)?;
         #[cfg(not(any(target_os = "ios", target_os = "macos")))]
-        termios::set_termios(fd.0, &termios)?;
+        termios::set_termios(fd.as_raw_fd(), &termios)?;
 
         // Return the final port object
         let mut port = TTYPort {
-            fd: fd.into_raw_fd(),
+            fd,
             timeout: builder.timeout,
             exclusive: builder.exclusive,
             port_name: Some(builder.path.clone()),
@@ -236,17 +222,17 @@ impl TTYPort {
     /// * `Io` for any error while setting exclusivity for the port.
     pub fn set_exclusive(&mut self, exclusive: bool) -> Result<()> {
         let setting_result = if exclusive {
-            ioctl::tiocexcl(self.fd)
+            ioctl::tiocexcl(self.fd.as_raw_fd())
         } else {
-            ioctl::tiocnxcl(self.fd)
+            ioctl::tiocnxcl(self.fd.as_raw_fd())
         };
 
         setting_result?;
 
         let flock_result = if exclusive {
-            flock::lock_exclusive(self.fd)
+            flock::lock_exclusive(self.fd.as_raw_fd())
         } else {
-            flock::lock_shared(self.fd)
+            flock::lock_shared(self.fd.as_raw_fd())
         };
 
         flock_result?;
@@ -257,14 +243,14 @@ impl TTYPort {
 
     fn set_pin(&mut self, pin: ioctl::SerialLines, level: bool) -> Result<()> {
         if level {
-            ioctl::tiocmbis(self.fd, pin)
+            ioctl::tiocmbis(self.fd.as_raw_fd(), pin)
         } else {
-            ioctl::tiocmbic(self.fd, pin)
+            ioctl::tiocmbic(self.fd.as_raw_fd(), pin)
         }
     }
 
     fn read_pin(&mut self, pin: ioctl::SerialLines) -> Result<bool> {
-        ioctl::tiocmget(self.fd).map(|pins| pins.contains(pin))
+        ioctl::tiocmget(self.fd.as_raw_fd()).map(|pins| pins.contains(pin))
     }
 
     /// Create a pair of pseudo serial terminals
@@ -320,28 +306,29 @@ impl TTYPort {
         #[cfg(any(target_os = "ios", target_os = "macos"))]
         let baud_rate = 9600;
 
-        // Wrap the slave fd in `OwnedFd` immediately so it auto-closes on error
-        let fd = OwnedFd(nix::fcntl::open(
+        let fd = nix::fcntl::open(
             Path::new(&ptty_name),
             OFlag::O_RDWR | OFlag::O_NOCTTY | OFlag::O_NONBLOCK,
             nix::sys::stat::Mode::empty(),
-        )?);
+        )?;
+        // Wrap the slave fd in `OwnedFd` immediately so it auto-closes on error
+        let fd = unsafe { OwnedFd::from_raw_fd(fd) };
 
         // Set the port to a raw state. Using these ports will not work without this.
         let mut termios = MaybeUninit::uninit();
-        Errno::result(unsafe { libc::tcgetattr(fd.0, termios.as_mut_ptr()) })?;
+        Errno::result(unsafe { libc::tcgetattr(fd.as_raw_fd(), termios.as_mut_ptr()) })?;
 
         let mut termios = unsafe { termios.assume_init() };
         unsafe { libc::cfmakeraw(&mut termios) };
-        Errno::result(unsafe { libc::tcsetattr(fd.0, libc::TCSANOW, &termios) })?;
+        Errno::result(unsafe { libc::tcsetattr(fd.as_raw_fd(), libc::TCSANOW, &termios) })?;
 
         fcntl(
-            fd.0,
+            fd.as_raw_fd(),
             nix::fcntl::FcntlArg::F_SETFL(nix::fcntl::OFlag::empty()),
         )?;
 
         let slave_tty = TTYPort {
-            fd: fd.into_raw_fd(),
+            fd,
             timeout: Duration::from_millis(100),
             exclusive: true,
             port_name: Some(ptty_name),
@@ -353,7 +340,7 @@ impl TTYPort {
         // `tcgetattr()` doesn't work on Mac, Solaris, and maybe other
         // BSDs when used on the master port.
         let master_tty = TTYPort {
-            fd: next_pty_fd.into_raw_fd(),
+            fd: unsafe { OwnedFd::from_raw_fd(next_pty_fd.into_raw_fd()) },
             timeout: Duration::from_millis(100),
             exclusive: true,
             port_name: None,
@@ -367,8 +354,8 @@ impl TTYPort {
     /// Sends 0-valued bits over the port for a set duration
     pub fn send_break(&self, duration: BreakDuration) -> Result<()> {
         match duration {
-            BreakDuration::Short => nix::sys::termios::tcsendbreak(self.fd, 0),
-            BreakDuration::Arbitrary(n) => nix::sys::termios::tcsendbreak(self.fd, n.get()),
+            BreakDuration::Short => nix::sys::termios::tcsendbreak(self.fd.as_fd(), 0),
+            BreakDuration::Arbitrary(n) => nix::sys::termios::tcsendbreak(self.fd.as_fd(), n.get()),
         }
         .map_err(|e| e.into())
     }
@@ -388,9 +375,12 @@ impl TTYPort {
     ///
     /// This function returns an error if the serial port couldn't be cloned.
     pub fn try_clone_native(&self) -> Result<TTYPort> {
-        let fd_cloned: i32 = fcntl(self.fd, nix::fcntl::F_DUPFD_CLOEXEC(self.fd))?;
+        let fd_cloned: i32 = fcntl(
+            self.fd.as_raw_fd(),
+            nix::fcntl::F_DUPFD_CLOEXEC(self.fd.as_raw_fd()),
+        )?;
         Ok(TTYPort {
-            fd: fd_cloned,
+            fd: unsafe { OwnedFd::from_raw_fd(fd_cloned) },
             exclusive: self.exclusive,
             port_name: self.port_name.clone(),
             timeout: self.timeout,
@@ -400,26 +390,15 @@ impl TTYPort {
     }
 }
 
-impl Drop for TTYPort {
-    fn drop(&mut self) {
-        close(self.fd);
-    }
-}
-
 impl AsRawFd for TTYPort {
     fn as_raw_fd(&self) -> RawFd {
-        self.fd
+        self.fd.as_raw_fd()
     }
 }
 
 impl IntoRawFd for TTYPort {
     fn into_raw_fd(self) -> RawFd {
-        // Pull just the file descriptor out. We also prevent the destructor
-        // from being run by calling `mem::forget`. If we didn't do this, the
-        // port would be closed, which would make `into_raw_fd` unusable.
-        let TTYPort { fd, .. } = self;
-        mem::forget(self);
-        fd
+        self.fd.into_raw_fd()
     }
 }
 
@@ -448,7 +427,7 @@ impl FromRawFd for TTYPort {
         let tiocexcl_successful = ioctl::tiocexcl(fd).is_ok();
 
         TTYPort {
-            fd,
+            fd: unsafe { OwnedFd::from_raw_fd(fd) },
             timeout: Duration::from_millis(100),
             exclusive: tiocexcl_successful && flock_successful,
             // It is not trivial to get the file path corresponding to a file descriptor.
@@ -465,27 +444,27 @@ impl FromRawFd for TTYPort {
 
 impl io::Read for TTYPort {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        if let Err(e) = super::poll::wait_read_fd(self.fd, self.timeout) {
+        if let Err(e) = super::poll::wait_read_fd(self.fd.as_fd(), self.timeout) {
             return Err(io::Error::from(Error::from(e)));
         }
 
-        nix::unistd::read(self.fd, buf).map_err(|e| io::Error::from(Error::from(e)))
+        nix::unistd::read(self.fd.as_raw_fd(), buf).map_err(|e| io::Error::from(Error::from(e)))
     }
 }
 
 impl io::Write for TTYPort {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        if let Err(e) = super::poll::wait_write_fd(self.fd, self.timeout) {
+        if let Err(e) = super::poll::wait_write_fd(self.fd.as_fd(), self.timeout) {
             return Err(io::Error::from(Error::from(e)));
         }
 
-        nix::unistd::write(self.fd, buf).map_err(|e| io::Error::from(Error::from(e)))
+        nix::unistd::write(self.fd.as_raw_fd(), buf).map_err(|e| io::Error::from(Error::from(e)))
     }
 
     fn flush(&mut self) -> io::Result<()> {
         let timeout = Instant::now() + self.timeout;
         loop {
-            return match nix::sys::termios::tcdrain(self.fd) {
+            return match nix::sys::termios::tcdrain(self.fd.as_fd()) {
                 Ok(_) => Ok(()),
                 Err(Errno::EINTR) => {
                     // Retry flushing. But only up to the ports timeout for not retrying
@@ -522,7 +501,7 @@ impl SerialPort for TTYPort {
         )
     ))]
     fn baud_rate(&self) -> Result<u32> {
-        let termios2 = ioctl::tcgets2(self.fd)?;
+        let termios2 = ioctl::tcgets2(self.fd.as_raw_fd())?;
 
         assert!(termios2.c_ospeed == termios2.c_ispeed);
 
@@ -540,7 +519,7 @@ impl SerialPort for TTYPort {
         target_os = "openbsd"
     ))]
     fn baud_rate(&self) -> Result<u32> {
-        let termios = termios::get_termios(self.fd)?;
+        let termios = termios::get_termios(self.fd.as_raw_fd())?;
 
         let ospeed = unsafe { libc::cfgetospeed(&termios) };
         let ispeed = unsafe { libc::cfgetispeed(&termios) };
@@ -577,7 +556,7 @@ impl SerialPort for TTYPort {
             B4800, B50, B57600, B600, B75, B9600,
         };
 
-        let termios = termios::get_termios(self.fd)?;
+        let termios = termios::get_termios(self.fd.as_raw_fd())?;
         let ospeed = unsafe { libc::cfgetospeed(&termios) };
         let ispeed = unsafe { libc::cfgetispeed(&termios) };
 
@@ -621,7 +600,7 @@ impl SerialPort for TTYPort {
     }
 
     fn data_bits(&self) -> Result<DataBits> {
-        let termios = termios::get_termios(self.fd)?;
+        let termios = termios::get_termios(self.fd.as_raw_fd())?;
         match termios.c_cflag & libc::CSIZE {
             libc::CS8 => Ok(DataBits::Eight),
             libc::CS7 => Ok(DataBits::Seven),
@@ -635,7 +614,7 @@ impl SerialPort for TTYPort {
     }
 
     fn flow_control(&self) -> Result<FlowControl> {
-        let termios = termios::get_termios(self.fd)?;
+        let termios = termios::get_termios(self.fd.as_raw_fd())?;
         if termios.c_cflag & libc::CRTSCTS == libc::CRTSCTS {
             Ok(FlowControl::Hardware)
         } else if termios.c_iflag & (libc::IXON | libc::IXOFF) == (libc::IXON | libc::IXOFF) {
@@ -646,7 +625,7 @@ impl SerialPort for TTYPort {
     }
 
     fn parity(&self) -> Result<Parity> {
-        let termios = termios::get_termios(self.fd)?;
+        let termios = termios::get_termios(self.fd.as_raw_fd())?;
         if termios.c_cflag & libc::PARENB == libc::PARENB {
             if termios.c_cflag & libc::PARODD == libc::PARODD {
                 Ok(Parity::Odd)
@@ -659,7 +638,7 @@ impl SerialPort for TTYPort {
     }
 
     fn stop_bits(&self) -> Result<StopBits> {
-        let termios = termios::get_termios(self.fd)?;
+        let termios = termios::get_termios(self.fd.as_raw_fd())?;
         if termios.c_cflag & libc::CSTOPB == libc::CSTOPB {
             Ok(StopBits::Two)
         } else {
@@ -680,53 +659,53 @@ impl SerialPort for TTYPort {
         target_os = "linux"
     ))]
     fn set_baud_rate(&mut self, baud_rate: u32) -> Result<()> {
-        let mut termios = termios::get_termios(self.fd)?;
+        let mut termios = termios::get_termios(self.fd.as_raw_fd())?;
         termios::set_baud_rate(&mut termios, baud_rate)?;
-        termios::set_termios(self.fd, &termios)
+        termios::set_termios(self.fd.as_raw_fd(), &termios)
     }
 
     // Mac OS needs special logic for setting arbitrary baud rates.
     #[cfg(any(target_os = "ios", target_os = "macos"))]
     fn set_baud_rate(&mut self, baud_rate: u32) -> Result<()> {
-        ioctl::iossiospeed(self.fd, &(baud_rate as libc::speed_t))?;
+        ioctl::iossiospeed(self.fd.as_raw_fd(), &(baud_rate as libc::speed_t))?;
         self.baud_rate = baud_rate;
         Ok(())
     }
 
     fn set_flow_control(&mut self, flow_control: FlowControl) -> Result<()> {
-        let mut termios = termios::get_termios(self.fd)?;
+        let mut termios = termios::get_termios(self.fd.as_raw_fd())?;
         termios::set_flow_control(&mut termios, flow_control);
         #[cfg(any(target_os = "ios", target_os = "macos"))]
-        return termios::set_termios(self.fd, &termios, self.baud_rate);
+        return termios::set_termios(self.fd.as_raw_fd(), &termios, self.baud_rate);
         #[cfg(not(any(target_os = "ios", target_os = "macos")))]
-        return termios::set_termios(self.fd, &termios);
+        return termios::set_termios(self.fd.as_raw_fd(), &termios);
     }
 
     fn set_parity(&mut self, parity: Parity) -> Result<()> {
-        let mut termios = termios::get_termios(self.fd)?;
+        let mut termios = termios::get_termios(self.fd.as_raw_fd())?;
         termios::set_parity(&mut termios, parity);
         #[cfg(any(target_os = "ios", target_os = "macos"))]
-        return termios::set_termios(self.fd, &termios, self.baud_rate);
+        return termios::set_termios(self.fd.as_raw_fd(), &termios, self.baud_rate);
         #[cfg(not(any(target_os = "ios", target_os = "macos")))]
-        return termios::set_termios(self.fd, &termios);
+        return termios::set_termios(self.fd.as_raw_fd(), &termios);
     }
 
     fn set_data_bits(&mut self, data_bits: DataBits) -> Result<()> {
-        let mut termios = termios::get_termios(self.fd)?;
+        let mut termios = termios::get_termios(self.fd.as_raw_fd())?;
         termios::set_data_bits(&mut termios, data_bits);
         #[cfg(any(target_os = "ios", target_os = "macos"))]
-        return termios::set_termios(self.fd, &termios, self.baud_rate);
+        return termios::set_termios(self.fd.as_raw_fd(), &termios, self.baud_rate);
         #[cfg(not(any(target_os = "ios", target_os = "macos")))]
-        return termios::set_termios(self.fd, &termios);
+        return termios::set_termios(self.fd.as_raw_fd(), &termios);
     }
 
     fn set_stop_bits(&mut self, stop_bits: StopBits) -> Result<()> {
-        let mut termios = termios::get_termios(self.fd)?;
+        let mut termios = termios::get_termios(self.fd.as_raw_fd())?;
         termios::set_stop_bits(&mut termios, stop_bits);
         #[cfg(any(target_os = "ios", target_os = "macos"))]
-        return termios::set_termios(self.fd, &termios, self.baud_rate);
+        return termios::set_termios(self.fd.as_raw_fd(), &termios, self.baud_rate);
         #[cfg(not(any(target_os = "ios", target_os = "macos")))]
-        return termios::set_termios(self.fd, &termios);
+        return termios::set_termios(self.fd.as_raw_fd(), &termios);
     }
 
     fn set_timeout(&mut self, timeout: Duration) -> Result<()> {
@@ -759,11 +738,11 @@ impl SerialPort for TTYPort {
     }
 
     fn bytes_to_read(&self) -> Result<u32> {
-        ioctl::fionread(self.fd)
+        ioctl::fionread(self.fd.as_raw_fd())
     }
 
     fn bytes_to_write(&self) -> Result<u32> {
-        ioctl::tiocoutq(self.fd)
+        ioctl::tiocoutq(self.fd.as_raw_fd())
     }
 
     fn clear(&self, buffer_to_clear: ClearBuffer) -> Result<()> {
@@ -773,7 +752,7 @@ impl SerialPort for TTYPort {
             ClearBuffer::All => libc::TCIOFLUSH,
         };
 
-        Errno::result(unsafe { libc::tcflush(self.fd, buffer_id) })
+        Errno::result(unsafe { libc::tcflush(self.fd.as_raw_fd(), buffer_id) })
             .map(|_| ())
             .map_err(|e| e.into())
     }
@@ -786,11 +765,11 @@ impl SerialPort for TTYPort {
     }
 
     fn set_break(&self) -> Result<()> {
-        ioctl::tiocsbrk(self.fd)
+        ioctl::tiocsbrk(self.fd.as_raw_fd())
     }
 
     fn clear_break(&self) -> Result<()> {
-        ioctl::tioccbrk(self.fd)
+        ioctl::tioccbrk(self.fd.as_raw_fd())
     }
 }
 

--- a/src/posix/tty.rs
+++ b/src/posix/tty.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use std::time::{Duration, Instant};
 
 use nix::errno::Errno;
-use nix::fcntl::{fcntl, FcntlArg, OFlag};
+use nix::fcntl::{fcntl, FcntlArg, Flock, FlockArg, OFlag};
 use nix::libc;
 
 use crate::posix::flock;
@@ -67,7 +67,7 @@ fn close(fd: RawFd) {
 /// ```
 #[derive(Debug)]
 pub struct TTYPort {
-    fd: OwnedFd,
+    fd: Flock<OwnedFd>,
     timeout: Duration,
     exclusive: bool,
     port_name: Option<String>,
@@ -113,12 +113,12 @@ impl TTYPort {
         // Set the requested access mode on the port. In exclusive mode use
         // TIOCEXCL and an exclusive flock to prevent other openers. In shared
         // mode we only need a shared flock to allow concurrent access.
-        if builder.exclusive {
+        let fd = if builder.exclusive {
             ioctl::tiocexcl(fd.as_raw_fd())?;
-            flock::lock_exclusive(fd.as_raw_fd())?;
+            flock::lock_exclusive(fd)?
         } else {
-            flock::lock_shared(fd.as_raw_fd())?;
-        }
+            flock::lock_shared(fd)?
+        };
         let mut termios = MaybeUninit::uninit();
         Errno::result(unsafe { libc::tcgetattr(fd.as_raw_fd(), termios.as_mut_ptr()) })?;
         let mut termios = unsafe { termios.assume_init() };
@@ -156,7 +156,7 @@ impl TTYPort {
         }
 
         // clear O_NONBLOCK flag
-        fcntl(&fd, FcntlArg::F_SETFL(nix::fcntl::OFlag::empty()))?;
+        fcntl(&*fd, FcntlArg::F_SETFL(nix::fcntl::OFlag::empty()))?;
 
         // Configure the low-level port settings
         let mut termios = termios::get_termios(fd.as_raw_fd())?;
@@ -226,9 +226,9 @@ impl TTYPort {
         setting_result?;
 
         let flock_result = if exclusive {
-            flock::lock_exclusive(self.fd.as_raw_fd())
+            flock::relock_exclusive(&self.fd)
         } else {
-            flock::lock_shared(self.fd.as_raw_fd())
+            flock::relock_shared(&self.fd)
         };
 
         flock_result?;
@@ -321,6 +321,7 @@ impl TTYPort {
             nix::fcntl::FcntlArg::F_SETFL(nix::fcntl::OFlag::empty()),
         )?;
 
+        let fd = flock::lock_exclusive(fd)?;
         let slave_tty = TTYPort {
             fd,
             timeout: Duration::from_millis(100),
@@ -330,11 +331,13 @@ impl TTYPort {
             baud_rate,
         };
 
+        let master_fd = unsafe { OwnedFd::from_raw_fd(next_pty_fd.into_raw_fd()) };
+        let master_fd = flock::lock_exclusive(master_fd)?;
         // Manually construct the master port here because the
         // `tcgetattr()` doesn't work on Mac, Solaris, and maybe other
         // BSDs when used on the master port.
         let master_tty = TTYPort {
-            fd: unsafe { OwnedFd::from_raw_fd(next_pty_fd.into_raw_fd()) },
+            fd: master_fd,
             timeout: Duration::from_millis(100),
             exclusive: true,
             port_name: None,
@@ -348,8 +351,8 @@ impl TTYPort {
     /// Sends 0-valued bits over the port for a set duration
     pub fn send_break(&self, duration: BreakDuration) -> Result<()> {
         match duration {
-            BreakDuration::Short => nix::sys::termios::tcsendbreak(&self.fd, 0),
-            BreakDuration::Arbitrary(n) => nix::sys::termios::tcsendbreak(&self.fd, n.get()),
+            BreakDuration::Short => nix::sys::termios::tcsendbreak(&*self.fd, 0),
+            BreakDuration::Arbitrary(n) => nix::sys::termios::tcsendbreak(&*self.fd, n.get()),
         }
         .map_err(|e| e.into())
     }
@@ -369,9 +372,14 @@ impl TTYPort {
     ///
     /// This function returns an error if the serial port couldn't be cloned.
     pub fn try_clone_native(&self) -> Result<TTYPort> {
-        let fd_cloned: i32 = fcntl(&self.fd, nix::fcntl::F_DUPFD_CLOEXEC(self.fd.as_raw_fd()))?;
+        let fd_cloned = self.fd.try_clone()?;
+        let fd_cloned = if self.exclusive {
+            flock::lock_exclusive(fd_cloned)
+        } else {
+            flock::lock_shared(fd_cloned)
+        }?;
         Ok(TTYPort {
-            fd: unsafe { OwnedFd::from_raw_fd(fd_cloned) },
+            fd: fd_cloned,
             exclusive: self.exclusive,
             port_name: self.port_name.clone(),
             timeout: self.timeout,
@@ -389,7 +397,7 @@ impl AsRawFd for TTYPort {
 
 impl IntoRawFd for TTYPort {
     fn into_raw_fd(self) -> RawFd {
-        self.fd.into_raw_fd()
+        self.fd.unlock().unwrap().into_raw_fd()
     }
 }
 
@@ -407,7 +415,19 @@ fn get_termios_speed(fd: RawFd) -> u32 {
 
 impl FromRawFd for TTYPort {
     unsafe fn from_raw_fd(fd: RawFd) -> Self {
-        let flock_successful = flock::lock_exclusive(fd).is_ok();
+        // SAFETY: Our caller promises that the file descriptor passed in must be owned.
+        let fd = unsafe { OwnedFd::from_raw_fd(fd) };
+
+        let (fd, flock_exclusive) = match Flock::lock(fd, FlockArg::LockExclusiveNonblock) {
+            Ok(fd) => (fd, true),
+            Err((fd, _)) => {
+                // Failed to lock exclusively, fall back to shared lock.
+                (
+                    Flock::lock(fd, FlockArg::LockSharedNonblock).expect("Failed to lock port"),
+                    false,
+                )
+            }
+        };
 
         // TODO: If we fail to get the exclusive lock, this probably means that
         // another process is using the port, and we should return an error,
@@ -415,20 +435,22 @@ impl FromRawFd for TTYPort {
         //
         // This will require a breaking change, as this method currently can't fail.
 
-        let tiocexcl_successful = ioctl::tiocexcl(fd).is_ok();
+        let tiocexcl_successful = ioctl::tiocexcl(fd.as_raw_fd()).is_ok();
 
+        // It's not guaranteed that the baud rate in the `termios` struct is correct, as
+        // setting an arbitrary baud rate via the `iossiospeed` ioctl overrides that value,
+        // but extract that value anyways as a best-guess of the actual baud rate.
+        #[cfg(any(target_os = "ios", target_os = "macos"))]
+        let baud_rate = get_termios_speed(fd.as_raw_fd());
         TTYPort {
-            fd: unsafe { OwnedFd::from_raw_fd(fd) },
+            fd,
             timeout: Duration::from_millis(100),
-            exclusive: tiocexcl_successful && flock_successful,
+            exclusive: tiocexcl_successful && flock_exclusive,
             // It is not trivial to get the file path corresponding to a file descriptor.
             // We'll punt on it and set it to `None` here.
             port_name: None,
-            // It's not guaranteed that the baud rate in the `termios` struct is correct, as
-            // setting an arbitrary baud rate via the `iossiospeed` ioctl overrides that value,
-            // but extract that value anyways as a best-guess of the actual baud rate.
             #[cfg(any(target_os = "ios", target_os = "macos"))]
-            baud_rate: get_termios_speed(fd),
+            baud_rate,
         }
     }
 }
@@ -439,7 +461,7 @@ impl io::Read for TTYPort {
             return Err(io::Error::from(Error::from(e)));
         }
 
-        nix::unistd::read(&self.fd, buf).map_err(|e| io::Error::from(Error::from(e)))
+        nix::unistd::read(&*self.fd, buf).map_err(|e| io::Error::from(Error::from(e)))
     }
 }
 
@@ -449,13 +471,13 @@ impl io::Write for TTYPort {
             return Err(io::Error::from(Error::from(e)));
         }
 
-        nix::unistd::write(&self.fd, buf).map_err(|e| io::Error::from(Error::from(e)))
+        nix::unistd::write(&*self.fd, buf).map_err(|e| io::Error::from(Error::from(e)))
     }
 
     fn flush(&mut self) -> io::Result<()> {
         let timeout = Instant::now() + self.timeout;
         loop {
-            return match nix::sys::termios::tcdrain(&self.fd) {
+            return match nix::sys::termios::tcdrain(&*self.fd) {
                 Ok(_) => Ok(()),
                 Err(Errno::EINTR) => {
                     // Retry flushing. But only up to the ports timeout for not retrying

--- a/tests/test_file_locking.rs
+++ b/tests/test_file_locking.rs
@@ -197,7 +197,7 @@ mod second_exclusive_open {
     fn fails_after_flock(hw_config: HardwareConfig, #[case] first_mode: FlockArg) {
         // Open the port file for the first time, keep it open, and flock it in the specified mode.
         let first = checks::open_file_successful(&hw_config);
-        let _ = Flock::lock(first, first_mode).unwrap();
+        let _locked = Flock::lock(first, first_mode).unwrap();
 
         // Opening the same port exclusively for a second time is expected to fail regardless of
         // the previous mode.
@@ -294,7 +294,7 @@ mod second_non_exclusive_open {
     fn after_flock(hw_config: HardwareConfig, #[case] first_mode: LockMode) {
         // Open the port file for the first time, keep it open, and flock it in the specified mode.
         let first = checks::open_file_successful(&hw_config);
-        let _ = Flock::lock(first, first_mode.into()).unwrap();
+        let _locked = Flock::lock(first, first_mode.into()).unwrap();
 
         // Open the same port for a second time.
         match first_mode {

--- a/tests/test_file_locking.rs
+++ b/tests/test_file_locking.rs
@@ -21,7 +21,7 @@ use serialport::SerialPort;
 cfg_if! {
     if #[cfg(unix)] {
         use std::os::unix::prelude::*;
-        use nix::fcntl::FlockArg;
+        use nix::fcntl::{FlockArg, Flock};
         use nix::ioctl_none_bad;
 
         // Locally create a wrapper for the TIOCEXCL and TIOCNXCL ioctl.
@@ -197,8 +197,7 @@ mod second_exclusive_open {
     fn fails_after_flock(hw_config: HardwareConfig, #[case] first_mode: FlockArg) {
         // Open the port file for the first time, keep it open, and flock it in the specified mode.
         let first = checks::open_file_successful(&hw_config);
-        let fd = first.as_raw_fd();
-        nix::fcntl::flock(fd, first_mode).unwrap();
+        let _ = Flock::lock(first, first_mode).unwrap();
 
         // Opening the same port exclusively for a second time is expected to fail regardless of
         // the previous mode.
@@ -295,7 +294,7 @@ mod second_non_exclusive_open {
     fn after_flock(hw_config: HardwareConfig, #[case] first_mode: LockMode) {
         // Open the port file for the first time, keep it open, and flock it in the specified mode.
         let first = checks::open_file_successful(&hw_config);
-        nix::fcntl::flock(first.as_raw_fd(), first_mode.into()).unwrap();
+        let _ = Flock::lock(first, first_mode.into()).unwrap();
 
         // Open the same port for a second time.
         match first_mode {

--- a/tests/test_tty.rs
+++ b/tests/test_tty.rs
@@ -118,12 +118,10 @@ fn test_osx_pty_pair() {
 #[test]
 #[cfg_attr(any(target_os = "ios", target_os = "macos"), ignore)]
 fn test_ttyport_set_standard_baud() {
-    // `master` must be used here as Dropping it causes slave to be deleted by the OS.
-    // TODO: Convert this to a statement-level attribute once
-    //       https://github.com/rust-lang/rust/issues/15701 is on stable.
     // FIXME: Create a mutex across all tests for using `TTYPort::pair()` as it's not threadsafe
-    #![allow(unused_variables)]
-    let (master, mut slave) = TTYPort::pair().expect("Unable to create ptty pair");
+
+    // `master` must be used here as Dropping it causes slave to be deleted by the OS.
+    let (_master, mut slave) = TTYPort::pair().expect("Unable to create ptty pair");
 
     slave.set_baud_rate(9600).unwrap();
     assert_eq!(slave.baud_rate().unwrap(), 9600);
@@ -147,12 +145,10 @@ fn test_ttyport_set_standard_baud() {
     ignore
 )]
 fn test_ttyport_set_nonstandard_baud() {
-    // `master` must be used here as Dropping it causes slave to be deleted by the OS.
-    // TODO: Convert this to a statement-level attribute once
-    //       https://github.com/rust-lang/rust/issues/15701 is on stable.
     // FIXME: Create a mutex across all tests for using `TTYPort::pair()` as it's not threadsafe
-    #![allow(unused_variables)]
-    let (master, mut slave) = TTYPort::pair().expect("Unable to create ptty pair");
+
+    // `master` must be used here as Dropping it causes slave to be deleted by the OS.
+    let (_master, mut slave) = TTYPort::pair().expect("Unable to create ptty pair");
 
     slave.set_baud_rate(10000).unwrap();
     assert_eq!(slave.baud_rate().unwrap(), 10000);

--- a/tests/test_tty.rs
+++ b/tests/test_tty.rs
@@ -93,24 +93,18 @@ fn test_ttyport_timeout() {
 #[test]
 #[cfg(any(target_os = "ios", target_os = "macos"))]
 fn test_osx_pty_pair() {
-    #![allow(unused_variables)]
-    let (mut master, slave) = TTYPort::pair().expect("Unable to create ptty pair");
-    let (output_sink, output_stream) = std::sync::mpsc::sync_channel(1);
-    let name = slave.name().unwrap();
+    // FIXME: Create a mutex across all tests for using `TTYPort::pair()` as it's not threadsafe
+    let (mut master, mut slave) = TTYPort::pair().expect("Unable to create ptty pair");
 
-    master.write_all("12".as_bytes()).expect("");
+    let write_data =
+        b"0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~";
+    master.write_all(write_data).unwrap();
+    master.flush().unwrap();
 
-    let reader_thread = std::thread::spawn(move || {
-        let mut port = TTYPort::open(&serialport::new(&name, 0)).expect("unable to open");
-        let mut buffer = [0u8; 2];
-        let amount = port.read_exact(&mut buffer);
-        output_sink
-            .send(String::from_utf8(buffer.to_vec()).expect("buffer not read as valid utf-8"))
-            .expect("unable to send from thread");
-    });
+    let mut read_data = [0u8; 79];
+    slave.read_exact(&mut read_data).unwrap();
 
-    reader_thread.join().expect("unable to join sink thread");
-    assert_eq!(output_stream.recv().unwrap(), "12");
+    assert_eq!(write_data, &read_data);
 }
 
 // On Mac this should work (in fact used to in b77768a) but now fails. It's not functionality that


### PR DESCRIPTION
This rebases the work in #263 on top of the playground-5.0 branch and adds some cleanups, and moves to the new nix `Flock` API.