### PR TITLE
Pin dependencies for Clippy in CI too

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -93,7 +93,9 @@ jobs:
         # The command line arguments below are for Cargo 1.59.0. The have
         # changed with newer releases and need to be adjusted when bumbing our
         # MSRV.
-      - name: Build | pin some dependencies for building with MSRV
+        #
+        # NOTE: Please keep in sync with pinning for other jobs in ci.yaml.
+      - name: Build | pin some dependencies
         if: ${{ inputs.pin-incompatible-msrv-bump-dependencies == true }}
         run: |
           cargo update --precise 0.10.0 --package core-foundation

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,6 +61,23 @@ jobs:
         with:
           target: ${{ matrix.target }}
       - uses: swatinem/rust-cache@v2
+        # Pin some dependencies (for Clippy and our MSRV 1.59.0) just here in
+        # CI and not via Cargo.toml. The latter would enforce them to all users
+        # and not just the ones who want to build with an old Rust release. See
+        # issue https://github.com/serialport/serialport-rs/issues/324.
+        #
+        # The command line arguments below are for Cargo 1.59.0. The have
+        # changed with newer releases and need to be adjusted when bumbing our
+        # MSRV.
+        #
+        # NOTE: Please keep in sync with pinning for build jobs in build.yaml.
+      - name: Build | pin some dependencies for building with MSRV
+        run: |
+          cargo update --precise 0.10.0 --package core-foundation
+          cargo update --precise 0.2.163 --package libc
+          cargo update --precise 1.0.101 --package proc-macro2
+          cargo update --precise 1.0.40 --package quote
+          cargo update --precise 1.0.22 --package unicode-ident
       - run: cargo clippy --target ${{ matrix.target }}
       - run: cargo clippy --target ${{ matrix.target }} --all-features
 


### PR DESCRIPTION
The clippy lint incompatible_msrv got introduced with Rust 1.78.0 and otherwise generates warnings in CI runs.