### PR TITLE
Make UsbPortInfo::location optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,13 +98,13 @@ project adheres to [Semantic Versioning](https://semver.org/).
   [#251](https://github.com/serialport/serialport-rs/issues/251)
   [#243](https://github.com/serialport/serialport-rs/issues/243)
   [#239](https://github.com/serialport/serialport-rs/pull/239)
-  [#29](https://github.com/serialport/serialport-rs/pull/29)
+  [#29](https://github.com/serialport/serialport-rs/issues/29)
 
 ### Fixed
 
 * Fix reporting serial numbers with colons on Windows.
   [#279](https://github.com/serialport/serialport-rs/issues/279)
-  [#282](https://github.com/serialport/serialport-rs/issues/282)
+  [#282](https://github.com/serialport/serialport-rs/pull/282)
 * Setting arbitrary baud rates on Linux which resulted in issues when read back
   on Arch recently.
   [#281](https://github.com/serialport/serialport-rs/issues/281)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ project adheres to [Semantic Versioning](https://semver.org/).
   and `Location`.
   [#222](https://github.com/serialport/serialport-rs/issues/222)
   [#350](https://github.com/serialport/serialport-rs/pull/350)
+  [#360](https://github.com/serialport/serialport-rs/pull/360)
 
 ### Changed
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![crates.io version badge](https://img.shields.io/crates/v/serialport.svg)](https://crates.io/crates/serialport)
-[![Documentation](https://docs.rs/serialport/badge.svg)](https://docs.rs/serialport)
+[![Documentation](https://img.shields.io/docsrs/serialport/latest)](https://docs.rs/serialport)
 [![GitHub workflow status](https://img.shields.io/github/actions/workflow/status/serialport/serialport-rs/ci.yaml?branch=main&logo=github)](https://github.com/serialport/serialport-rs/actions)
 [![Minimum Stable Rust Version](https://img.shields.io/badge/Rust-1.59.0-blue?logo=rust)](https://blog.rust-lang.org/2022/02/24/Rust-1.59.0.html)
 

--- a/examples/list_ports.rs
+++ b/examples/list_ports.rs
@@ -21,7 +21,9 @@ fn main() {
                         println!("        VID: {:04x}", info.vid);
                         println!("        PID: {:04x}", info.pid);
                         #[cfg(feature = "usbportinfo-location")]
-                        println!("        Location: {}", info.location);
+                        if let Some(location) = info.location {
+                            println!("        Location: {}", location);
+                        }
                         #[cfg(feature = "usbportinfo-interface")]
                         println!(
                             "        Interface: {}",

--- a/examples/list_ports.rs
+++ b/examples/list_ports.rs
@@ -20,6 +20,8 @@ fn main() {
                         println!("        Type: USB");
                         println!("        VID: {:04x}", info.vid);
                         println!("        PID: {:04x}", info.pid);
+                        #[cfg(feature = "usbportinfo-location")]
+                        println!("        Location: {}", info.location);
                         #[cfg(feature = "usbportinfo-interface")]
                         println!(
                             "        Interface: {}",
@@ -39,8 +41,6 @@ fn main() {
                             "        Product: {}",
                             info.product.as_ref().map_or("", String::as_str)
                         );
-                        #[cfg(feature = "usbportinfo-location")]
-                        println!("        Location: {}", info.location);
                     }
                     SerialPortType::BluetoothPort => {
                         println!("        Type: Bluetooth");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -931,8 +931,11 @@ pub enum LocationErrorKind {
 #[cfg(feature = "usbportinfo-location")]
 impl From<ParseIntError> for ParseLocationError {
     fn from(error: ParseIntError) -> ParseLocationError {
+        // TODO: Switch to copying instead of cloning of ParseIntError once this is supported on our
+        // MSRV too.
+        #[allow(clippy::clone_on_copy)]
         ParseLocationError {
-            kind: LocationErrorKind::Port(*error.kind()),
+            kind: LocationErrorKind::Port(error.kind().clone()),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -902,7 +902,8 @@ impl fmt::Display for Location {
 
 /// An error which can be returned when parsing a USB device location string.
 #[cfg(feature = "usbportinfo-location")]
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+// TODO: Derive Hash when our MSRV gives us an `IntErrorKind` implementing it.
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ParseLocationError {
     kind: LocationErrorKind,
 }
@@ -917,7 +918,8 @@ impl ParseLocationError {
 
 /// Enum to store the various types of errors that can cause parsing a USB device locaiton to fail.
 #[cfg(feature = "usbportinfo-location")]
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+// TODO: Derive Hash when our MSRV gives us an `IntErrorKind` implementing it.
+#[derive(Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum LocationErrorKind {
     /// Parsing a port number in the port chain failed.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -874,12 +874,13 @@ impl Location {
     /// Returns the parent of this device, if any. Root objects have no parent.
     pub fn parent(&self) -> Option<Location> {
         if self.port_chain.len() <= 1 {
-            return None;
+            None
+        } else {
+            Some(Location {
+                bus_id: self.bus_id.clone(),
+                port_chain: self.port_chain[0..self.port_chain.len() - 1].to_owned(),
+            })
         }
-        Some(Location {
-            bus_id: self.bus_id.clone(),
-            port_chain: self.port_chain[0..self.port_chain.len() - 1].to_owned(),
-        })
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -829,7 +829,7 @@ pub struct UsbPortInfo {
     pub product: Option<String>,
     /// Physical port heirarchy
     #[cfg(feature = "usbportinfo-location")]
-    pub location: Location,
+    pub location: Option<Location>,
     /// The interface index of the USB serial port. This can be either the interface number of
     /// the communication interface (as is the case on Windows and Linux) or the data
     /// interface (as is the case on macOS), so you should recognize both interface numbers.
@@ -838,7 +838,7 @@ pub struct UsbPortInfo {
 }
 
 #[cfg(feature = "usbportinfo-location")]
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// Identify where a particular USB device is on the system.
 pub struct Location {
@@ -1111,7 +1111,7 @@ mod test {
             product: Some(String::from("your product here")),
             serial_number: Some(String::from("your serial_number here")),
             #[cfg(feature = "usbportinfo-location")]
-            location: Location::new(String::from("001"), Vec::new()),
+            location: Some(Location::new(String::from("001"), Vec::new())),
             #[cfg(feature = "usbportinfo-interface")]
             interface: Some(42),
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -850,11 +850,8 @@ pub struct Location {
 impl Location {
     /// Create a new USB device location based on some string identifying the bus number, along with
     /// the path taken to a particular port.
-    pub fn new(bus_id: &str, port_chain: &[u8]) -> Self {
-        Location {
-            bus_id: bus_id.to_owned(),
-            port_chain: port_chain.to_owned(),
-        }
+    pub fn new(bus_id: String, port_chain: Vec<u8>) -> Self {
+        Location { bus_id, port_chain }
     }
 
     /// Returns `true` if this Location is located below another Location in the bus hierarchy.
@@ -1114,7 +1111,7 @@ mod test {
             product: Some(String::from("your product here")),
             serial_number: Some(String::from("your serial_number here")),
             #[cfg(feature = "usbportinfo-location")]
-            location: Location::new("001", &[]),
+            location: Location::new(String::from("001"), Vec::new()),
             #[cfg(feature = "usbportinfo-interface")]
             interface: Some(42),
         };

--- a/src/posix/enumerate.rs
+++ b/src/posix/enumerate.rs
@@ -116,7 +116,7 @@ fn udev_restore_spaces(source: String) -> String {
 ))]
 /// Get the bus number and port chain out of the first parent device that
 /// has a defined bus number.
-fn port_location(device: &libudev::Device) -> crate::Location {
+fn port_location(device: &libudev::Device) -> Option<crate::Location> {
     let mut device = device.parent();
     while let Some(d) = device.take() {
         let busnum = udev_property_as_string(&d, "BUSNUM");
@@ -137,10 +137,7 @@ fn port_location(device: &libudev::Device) -> crate::Location {
         };
         let devpath = devpath.unwrap();
 
-        let bus_num = busnum
-            .parse()
-            .map(|n: u32| format!("{n:03}"))
-            .unwrap_or_default();
+        let bus_num = busnum.parse().map(|n: u32| format!("{n:03}"));
 
         let port_chain = devpath
             .rsplit_once("-")
@@ -150,12 +147,15 @@ fn port_location(device: &libudev::Device) -> crate::Location {
                 p.split('.')
                     .map(|v| v.parse::<u8>().ok())
                     .collect::<Option<Vec<u8>>>()
-            })
-            .unwrap_or_default();
-        return crate::Location::new(&bus_num, &port_chain);
+            });
+
+        return match (bus_num, port_chain) {
+            (Ok(bus_id), Some(port_chain)) => Some(crate::Location::new(bus_id, port_chain)),
+            _ => None,
+        };
     }
 
-    crate::Location::new("000", &[])
+    None
 }
 
 #[cfg(all(target_os = "linux", not(target_env = "musl"), feature = "libudev"))]
@@ -718,7 +718,7 @@ cfg_if! {
                 manufacturer,
                 product,
                 #[cfg(feature = "usbportinfo-location")]
-                location,
+                location: Some(location),
                 #[cfg(feature = "usbportinfo-interface")]
                 interface,
             })

--- a/src/posix/enumerate.rs
+++ b/src/posix/enumerate.rs
@@ -137,7 +137,7 @@ fn port_location(device: &libudev::Device) -> Option<crate::Location> {
         };
         let devpath = devpath.unwrap();
 
-        let bus_num = busnum.parse().map(|n: u32| format!("{n:03}"));
+        let bus_num = busnum.parse().map(|n: u32| format!("{n}"));
 
         let port_chain = devpath
             .rsplit_once("-")
@@ -426,9 +426,7 @@ impl crate::Location {
     pub fn from_location_id(id: u32) -> crate::Location {
         let bytes = id.to_be_bytes();
 
-        // TODO: What's the reason for formatting the bus ID with trailing zeroes? This format also
-        // differs from formatting it to three digits on Linux.
-        let bus_id = format!("{:02}", bytes[0]);
+        let bus_id = format!("{}", bytes[0]);
 
         // Convert remaining bytes into nibbles and trim trailing zeroes. When trailing zeroes are
         // not used, I would have expected zeroes in between non-zero ports to be invalid. But this

--- a/src/posix/enumerate.rs
+++ b/src/posix/enumerate.rs
@@ -446,8 +446,8 @@ fn port_type(service: io_object_t) -> SerialPortType {
             product: get_string_property(usb_device, "USB Product Name").ok(),
             #[cfg(feature = "usbportinfo-location")]
             location: crate::Location::new(
-                &format!("{:02x}", (location_id >> 24) as u8),
-                &parse_location_id(location_id),
+                format!("{:02x}", (location_id >> 24) as u8),
+                parse_location_id(location_id),
             ),
             // Apple developer documentation indicates `bInterfaceNumber` is the supported key for
             // looking up the composite usb interface id. `idVendor` and `idProduct` are included in the same tables, so
@@ -708,7 +708,7 @@ cfg_if! {
                     })
                     .unwrap_or_default();
 
-                crate::Location::new(&bus_id, &port_chain)
+                crate::Location::new(bus_id, port_chain)
             };
 
             Some(UsbPortInfo {

--- a/src/posix/enumerate.rs
+++ b/src/posix/enumerate.rs
@@ -412,17 +412,36 @@ fn get_string_property(device_type: io_registry_entry_t, property: &str) -> Resu
     any(target_os = "ios", target_os = "macos"),
     feature = "usbportinfo-location"
 ))]
-fn parse_location_id(id: u32) -> Vec<u8> {
-    let mut chain = vec![];
-    let mut shift = id << 8;
+impl crate::Location {
+    /// Creates a `Location` from a location ID from Apple's I/O registry.
+    ///
+    /// There is no information from Apple on this format. This is how [nusb's
+    /// `parse_location_id`](https://github.com/kevinmehall/nusb/blob/e9343c3c6ccd227206631015098b2f27b7e3ec5f/src/platform/macos_iokit/enumeration.rs#L276)
+    /// interprets it:
+    ///
+    /// The format of the ID is expected to be in the form of `0xBBPPPPPP` where `BB` is the bus ID
+    /// and `P` a nibble containing a port number. USB allows ub to 5 hubs between the root hub and
+    /// the device and so the location ID can capture the entire port chain. Trailing port numbers
+    /// of zero will be ignored.
+    pub fn from_location_id(id: u32) -> crate::Location {
+        let bytes = id.to_be_bytes();
 
-    while shift != 0 {
-        let port = shift >> 28;
-        chain.push(port as u8);
-        shift <<= 4;
+        // TODO: What's the reason for formatting the bus ID with trailing zeroes? This format also
+        // differs from formatting it to three digits on Linux.
+        let bus_id = format!("{:02}", bytes[0]);
+
+        // Convert remaining bytes into nibbles and trim trailing zeroes. When trailing zeroes are
+        // not used, I would have expected zeroes in between non-zero ports to be invalid. But this
+        // is how nusb does it and I'm leaving it this way for the time being.
+        let mut ports: Vec<u8> = bytes[1..].iter().flat_map(|b| [b >> 4, b & 0xf]).collect();
+        if let Some(last_populated) = ports.iter().rposition(|n| *n != 0) {
+            ports.truncate(last_populated + 1);
+        } else {
+            ports.clear();
+        }
+
+        crate::Location::new(bus_id, ports)
     }
-
-    chain
 }
 
 #[cfg(any(target_os = "ios", target_os = "macos"))]
@@ -436,8 +455,6 @@ fn port_type(service: io_object_t) -> SerialPortType {
     let maybe_usb_device = get_parent_device_by_type(service, usb_device_class_name)
         .or_else(|| get_parent_device_by_type(service, legacy_usb_device_class_name));
     if let Some(usb_device) = maybe_usb_device {
-        #[cfg(feature = "usbportinfo-location")]
-        let location_id = get_int_property(usb_device, "locationID").unwrap_or_default();
         SerialPortType::UsbPort(UsbPortInfo {
             vid: get_int_property(usb_device, "idVendor").unwrap_or_default() as u16,
             pid: get_int_property(usb_device, "idProduct").unwrap_or_default() as u16,
@@ -445,10 +462,9 @@ fn port_type(service: io_object_t) -> SerialPortType {
             manufacturer: get_string_property(usb_device, "USB Vendor Name").ok(),
             product: get_string_property(usb_device, "USB Product Name").ok(),
             #[cfg(feature = "usbportinfo-location")]
-            location: crate::Location::new(
-                format!("{:02x}", (location_id >> 24) as u8),
-                parse_location_id(location_id),
-            ),
+            location: get_int_property(usb_device, "locationID")
+                .ok()
+                .map(crate::Location::from_location_id),
             // Apple developer documentation indicates `bInterfaceNumber` is the supported key for
             // looking up the composite usb interface id. `idVendor` and `idProduct` are included in the same tables, so
             // we will lookup the interface number using the same method. See:

--- a/src/windows/enumerate.rs
+++ b/src/windows/enumerate.rs
@@ -200,7 +200,7 @@ fn parse_location_path(s: &str) -> Option<crate::Location> {
     let close_i = s[start_i + usbroot.len()..].find(')')?;
     let (bus, mut s) = s.split_at(start_i + usbroot.len() + close_i + 1);
 
-    let mut path = vec![];
+    let mut path = Vec::new();
 
     while let Some((_, next)) = s.split_once("#USB(") {
         let (port_num, next) = next.split_once(")")?;
@@ -208,7 +208,7 @@ fn parse_location_path(s: &str) -> Option<crate::Location> {
         s = next;
     }
 
-    Some(crate::Location::new(bus, &path))
+    Some(crate::Location::new(bus.to_owned(), path))
 }
 
 struct PortDevices {

--- a/src/windows/enumerate.rs
+++ b/src/windows/enumerate.rs
@@ -422,8 +422,7 @@ impl PortDevice {
                     let location_paths = self.property_list(SPDRP_LOCATION_PATHS);
                     info.location = location_paths
                         .iter()
-                        .find_map(|p| parse_location_path(p))
-                        .unwrap_or_default();
+                        .find_map(|p| parse_location_path(p));
                 }
 
                 SerialPortType::UsbPort(info)


### PR DESCRIPTION
I overlooked the use of default values where an `Option<Location>` would be more idiomatic in #350. I also overlooked some issues with MSRV builds. This PR cleans these things up.

Semver checks are expected to fail because they are not taking into account that `UsbPortInfo::location` is preview feature-gated.