### PR TITLE
Express intent of "no location" more clearly

### DIFF
--- a/src/posix/enumerate.rs
+++ b/src/posix/enumerate.rs
@@ -315,7 +315,7 @@ fn parse_modalias(moda: &str) -> Option<UsbPortInfo> {
         manufacturer: None,
         product: None,
         #[cfg(feature = "usbportinfo-location")]
-        location: Default::default(),
+        location: None,
         // Only attempt to find the interface if the feature is enabled.
         #[cfg(feature = "usbportinfo-interface")]
         interface: mod_tail.get(pid_start + 4..).and_then(|mod_tail| {

--- a/src/windows/enumerate.rs
+++ b/src/windows/enumerate.rs
@@ -186,7 +186,7 @@ fn parse_usb_port_info(hardware_id: &str, parent_hardware_id: Option<&str>) -> O
         product: None,
 
         #[cfg(feature = "usbportinfo-location")]
-        location: Default::default(),
+        location: None,
 
         #[cfg(feature = "usbportinfo-interface")]
         interface,


### PR DESCRIPTION
These two slipped through in #360. With the switch to Option<Location> these were convoluted `None`s we can express more clearly.