### PR TITLE
Enable UsbPortInfo::location in CI tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -143,8 +143,8 @@ jobs:
 
       - name: Build | build tests (selected features)
         if: ${{ inputs.disable_extra_builds == false }}
-        run: cargo build --tests --features libudev,usbportinfo-interface --target=${{ inputs.target }}
+        run: cargo build --tests --features libudev,usbportinfo-interface,usbportinfo-location --target=${{ inputs.target }}
 
       - name: Build | run tests (selected features)
         if: ${{ inputs.disable_tests == false }}
-        run: cargo test --no-fail-fast --features libudev,usbportinfo-interface --target=${{ inputs.target }}
+        run: cargo test --no-fail-fast --features libudev,usbportinfo-interface,usbportinfo-location --target=${{ inputs.target }}


### PR DESCRIPTION
Tests are already built with UsbPortInfo::interface enabled. So location information should be enabled as well. I missed this in #360.