### PR TITLE
Clean up CI runs and fmt::Debug impl for Location 

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,3 +1,7 @@
 # Ignore links to issues on GitLab which are no longer reachable since we
 # disabled bug tracking over there.
 https://gitlab.com/susurrus/serialport-rs/(-/)?merge_requests/\d+
+
+# Ignore link to external documentation frequently but spuriously returning
+# HTTP error 415, 'Unsupported Media Type'.
+http://freeware.the-meiers.org/

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -988,6 +988,11 @@ impl std::fmt::Debug for UsbPortInfo {
             .field("manufacturer", &self.manufacturer)
             .field("product", &self.product);
 
+        #[cfg(feature = "usbportinfo-location")]
+        {
+            d.field("location", &self.location);
+        }
+
         #[cfg(feature = "usbportinfo-interface")]
         {
             d.field("interface", &self.interface);
@@ -1117,7 +1122,7 @@ mod test {
             product: Some(String::from("your product here")),
             serial_number: Some(String::from("your serial_number here")),
             #[cfg(feature = "usbportinfo-location")]
-            location: Some(Location::new(String::from("001"), Vec::new())),
+            location: Some(Location::new(String::from("001"), vec![1, 2, 3])),
             #[cfg(feature = "usbportinfo-interface")]
             interface: Some(42),
         };
@@ -1125,10 +1130,19 @@ mod test {
 
         // Set the expectiation for the debug representation basend on a "snapshot" of the current
         // one, manually cross-checked to contain a VID and PID in hexadecimal digits.
-        #[cfg(not(feature = "usbportinfo-interface"))]
-        let expected = "UsbPortInfo { vid: 0xbade, pid: 0xaffe, serial_number: Some(\"your serial_number here\"), manufacturer: Some(\"your manufacutrer here\"), product: Some(\"your product here\") }";
+        //
+        // Due to having multiple configuration variants, we are building the expectation depending
+        // on the currently selected preview features.
+        let mut expected = String::from("UsbPortInfo { vid: 0xbade, pid: 0xaffe, serial_number: Some(\"your serial_number here\"), manufacturer: Some(\"your manufacutrer here\"), product: Some(\"your product here\")");
+        #[cfg(feature = "usbportinfo-location")]
+        {
+            expected += ", location: Some(Location { bus_id: \"001\", port_chain: [1, 2, 3] })";
+        }
         #[cfg(feature = "usbportinfo-interface")]
-        let expected = "UsbPortInfo { vid: 0xbade, pid: 0xaffe, serial_number: Some(\"your serial_number here\"), manufacturer: Some(\"your manufacutrer here\"), product: Some(\"your product here\"), interface: Some(42) }";
+        {
+            expected += ", interface: Some(42)";
+        }
+        expected += " }";
 
         assert_eq!(formatted, expected);
     }

--- a/src/posix/enumerate.rs
+++ b/src/posix/enumerate.rs
@@ -668,6 +668,26 @@ cfg_if! {
             u8::from_str_radix(&read_file_to_trimmed_string(dir, file)?, 16).ok()
         }
 
+        #[cfg(feature = "usbportinfo-location")]
+        fn read_location(dir: &Path) -> Option<crate::Location> {
+            let bus_id = read_file_to_trimmed_string(dir, "busnum")
+                .and_then(|s| u32::from_str_radix(&s, 10).ok())
+                .map(|n| format!("{n:03}"));
+
+            let port_chain = read_file_to_trimmed_string(dir, "devpath")
+                .filter(|p| p != "0") // root hub should be empty but devpath is 0
+                .and_then(|p| {
+                    p.split('.')
+                        .map(|v| v.parse::<u8>().ok())
+                        .collect::<Option<Vec<u8>>>()
+                });
+
+            match (bus_id, port_chain) {
+                (Some(bus_id), Some(port_chain)) => Some(crate::Location::new(bus_id, port_chain)),
+                _ => None,
+            }
+        }
+
         fn read_port_type(path: &Path) -> Option<SerialPortType> {
             let path = path
                 .canonicalize()
@@ -697,33 +717,13 @@ cfg_if! {
 
             let vid = read_file_to_u16(device_path, "idVendor")?;
             let pid = read_file_to_u16(device_path, "idProduct")?;
+            #[cfg(feature = "usbportinfo-location")]
+            let location = read_location(device_path)?;
             #[cfg(feature = "usbportinfo-interface")]
             let interface = read_file_to_u8(interface_path, "bInterfaceNumber");
             let serial_number = read_file_to_trimmed_string(device_path, "serial");
             let product = read_file_to_trimmed_string(device_path, "product");
             let manufacturer = read_file_to_trimmed_string(device_path, "manufacturer");
-
-            #[cfg(feature = "usbportinfo-location")]
-            let location = {
-                let bus_id = if let Some(busnum) = read_file_to_trimmed_string(device_path, "busnum") {
-                    u32::from_str_radix(&busnum, 10)
-                    .map(|n| format!("{n:03}"))
-                    .unwrap_or_default()
-                } else {
-                    "000".to_owned()
-                };
-
-                let port_chain = read_file_to_trimmed_string(device_path, "devpath")
-                    .filter(|p| p != "0") // root hub should be empty but devpath is 0
-                    .and_then(|p| {
-                        p.split('.')
-                            .map(|v| v.parse::<u8>().ok())
-                            .collect::<Option<Vec<u8>>>()
-                    })
-                    .unwrap_or_default();
-
-                crate::Location::new(bus_id, port_chain)
-            };
 
             Some(UsbPortInfo {
                 vid,

--- a/src/posix/enumerate.rs
+++ b/src/posix/enumerate.rs
@@ -672,7 +672,7 @@ cfg_if! {
         fn read_location(dir: &Path) -> Option<crate::Location> {
             let bus_id = read_file_to_trimmed_string(dir, "busnum")
                 .and_then(|s| u32::from_str_radix(&s, 10).ok())
-                .map(|n| format!("{n:03}"));
+                .map(|n| format!("{n}"));
 
             let port_chain = read_file_to_trimmed_string(dir, "devpath")
                 .filter(|p| p != "0") // root hub should be empty but devpath is 0


### PR DESCRIPTION
I did not spot that the implementation of `fmt::Debug` for `UsbPortInfo` was missing the new `location` field in #360. The location preview feature was also not active in CI and the capricious results from link-checking really started to bug me.