### PR TITLE
Make platform-specific serial parameters conditional at compile time

### DIFF
--- a/examples/hardware_check.rs
+++ b/examples/hardware_check.rs
@@ -227,6 +227,7 @@ fn test_single_port(port: &mut serialport::SerialPort, loopback: bool) {
     // Test setting stop bits
     println!("Testing stop bits...");
     stop_bits_check!(port, StopBits::Two);
+    stop_bits_check!(port, StopBits::OnePointFive);
     stop_bits_check!(port, StopBits::One);
 
     // Test bytes to read and write

--- a/examples/hardware_check.rs
+++ b/examples/hardware_check.rs
@@ -227,6 +227,7 @@ fn test_single_port(port: &mut serialport::SerialPort, loopback: bool) {
     // Test setting stop bits
     println!("Testing stop bits...");
     stop_bits_check!(port, StopBits::Two);
+    #[cfg(target_os = "windows")]
     stop_bits_check!(port, StopBits::OnePointFive);
     stop_bits_check!(port, StopBits::One);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,6 +211,16 @@ pub enum Parity {
 
     /// Parity bit sets even number of 1 bits.
     Even,
+
+    /// Parity bit is set to 1.
+    ///
+    /// Only supported on Windows and Linux.
+    Mark,
+
+    /// Parity bit is set to 0.
+    ///
+    /// Only supported on Windows and Linux.
+    Space,
 }
 
 impl fmt::Display for Parity {
@@ -219,6 +229,8 @@ impl fmt::Display for Parity {
             Parity::None => write!(f, "None"),
             Parity::Odd => write!(f, "Odd"),
             Parity::Even => write!(f, "Even"),
+            Parity::Mark => write!(f, "Mark"),
+            Parity::Space => write!(f, "Space"),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,11 +246,13 @@ impl fmt::Display for Parity {
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[non_exhaustive]
 pub enum StopBits {
     /// One stop bit.
     One,
 
     /// One and a half stop bits.
+    #[cfg(target_os = "windows")]
     OnePointFive,
 
     /// Two stop bits.
@@ -261,6 +263,7 @@ impl fmt::Display for StopBits {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             StopBits::One => write!(f, "One"),
+            #[cfg(target_os = "windows")]
             StopBits::OnePointFive => write!(f, "OnePointFive"),
             StopBits::Two => write!(f, "Two"),
         }
@@ -271,6 +274,7 @@ impl From<StopBits> for u8 {
     fn from(value: StopBits) -> Self {
         match value {
             StopBits::One => 1,
+            #[cfg(target_os = "windows")]
             StopBits::OnePointFive => 1,
             StopBits::Two => 2,
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -250,6 +250,9 @@ pub enum StopBits {
     /// One stop bit.
     One,
 
+    /// One and a half stop bits.
+    OnePointFive,
+
     /// Two stop bits.
     Two,
 }
@@ -258,6 +261,7 @@ impl fmt::Display for StopBits {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             StopBits::One => write!(f, "One"),
+            StopBits::OnePointFive => write!(f, "OnePointFive"),
             StopBits::Two => write!(f, "Two"),
         }
     }
@@ -267,6 +271,7 @@ impl From<StopBits> for u8 {
     fn from(value: StopBits) -> Self {
         match value {
             StopBits::One => 1,
+            StopBits::OnePointFive => 1,
             StopBits::Two => 2,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,6 +202,7 @@ impl TryFrom<u8> for DataBits {
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[non_exhaustive]
 pub enum Parity {
     /// No parity bit.
     None,
@@ -215,11 +216,13 @@ pub enum Parity {
     /// Parity bit is set to 1.
     ///
     /// Only supported on Windows and Linux.
+    #[cfg(any(target_os = "windows", target_os = "linux", target_os = "android"))]
     Mark,
 
     /// Parity bit is set to 0.
     ///
     /// Only supported on Windows and Linux.
+    #[cfg(any(target_os = "windows", target_os = "linux", target_os = "android"))]
     Space,
 }
 
@@ -229,7 +232,9 @@ impl fmt::Display for Parity {
             Parity::None => write!(f, "None"),
             Parity::Odd => write!(f, "Odd"),
             Parity::Even => write!(f, "Even"),
+            #[cfg(any(target_os = "windows", target_os = "linux", target_os = "android"))]
             Parity::Mark => write!(f, "Mark"),
+            #[cfg(any(target_os = "windows", target_os = "linux", target_os = "android"))]
             Parity::Space => write!(f, "Space"),
         }
     }

--- a/src/posix/termios.rs
+++ b/src/posix/termios.rs
@@ -124,25 +124,71 @@ pub(crate) fn set_termios(fd: RawFd, termios: &Termios) -> Result<()> {
     crate::posix::ioctl::tcsets2(fd, termios)
 }
 
-pub(crate) fn set_parity(termios: &mut Termios, parity: Parity) {
+// The Result return will seem pointless on platforms that support all parity variants, but we need
+// it for the others.
+#[allow(clippy::unnecessary_wraps)]
+pub(crate) fn set_parity(termios: &mut Termios, parity: Parity) -> Result<()> {
     match parity {
         Parity::None => {
             termios.c_cflag &= !(libc::PARENB | libc::PARODD);
             termios.c_iflag &= !libc::INPCK;
             termios.c_iflag |= libc::IGNPAR;
+            #[cfg(any(target_os = "linux", target_os = "android"))]
+            {
+                termios.c_iflag &= !libc::CMSPAR;
+            }
         }
         Parity::Odd => {
             termios.c_cflag |= libc::PARENB | libc::PARODD;
             termios.c_iflag |= libc::INPCK;
             termios.c_iflag &= !libc::IGNPAR;
+            #[cfg(any(target_os = "linux", target_os = "android"))]
+            {
+                termios.c_iflag &= !libc::CMSPAR;
+            }
         }
         Parity::Even => {
             termios.c_cflag &= !libc::PARODD;
             termios.c_cflag |= libc::PARENB;
             termios.c_iflag |= libc::INPCK;
             termios.c_iflag &= !libc::IGNPAR;
+            #[cfg(any(target_os = "linux", target_os = "android"))]
+            {
+                termios.c_iflag &= !libc::CMSPAR;
+            }
+        }
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        Parity::Mark => {
+            termios.c_cflag |= libc::PARODD;
+            termios.c_cflag |= libc::PARENB;
+            termios.c_iflag |= libc::INPCK;
+            termios.c_iflag &= !libc::IGNPAR;
+            termios.c_iflag |= libc::CMSPAR;
+        }
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        Parity::Space => {
+            termios.c_cflag &= !libc::PARODD;
+            termios.c_cflag |= libc::PARENB;
+            termios.c_iflag |= libc::INPCK;
+            termios.c_iflag &= !libc::IGNPAR;
+            termios.c_iflag |= libc::CMSPAR;
+        }
+        #[cfg(not(any(target_os = "linux", target_os = "android")))]
+        Parity::Mark => {
+            return Err(crate::Error::new(
+                crate::ErrorKind::InvalidInput,
+                "Mark parity not supported on this platform",
+            ));
+        }
+        #[cfg(not(any(target_os = "linux", target_os = "android")))]
+        Parity::Space => {
+            return Err(crate::Error::new(
+                crate::ErrorKind::InvalidInput,
+                "Space parity not supported on this platform",
+            ));
         }
     };
+    Ok(())
 }
 
 pub(crate) fn set_flow_control(termios: &mut Termios, flow_control: FlowControl) {

--- a/src/posix/termios.rs
+++ b/src/posix/termios.rs
@@ -205,6 +205,7 @@ pub(crate) fn set_data_bits(termios: &mut Termios, data_bits: DataBits) {
 pub(crate) fn set_stop_bits(termios: &mut Termios, stop_bits: StopBits) {
     match stop_bits {
         StopBits::One => termios.c_cflag &= !libc::CSTOPB,
+        StopBits::OnePointFive => termios.c_cflag &= !libc::CSTOPB,
         StopBits::Two => termios.c_cflag |= libc::CSTOPB,
     };
 }

--- a/src/posix/termios.rs
+++ b/src/posix/termios.rs
@@ -124,10 +124,7 @@ pub(crate) fn set_termios(fd: RawFd, termios: &Termios) -> Result<()> {
     crate::posix::ioctl::tcsets2(fd, termios)
 }
 
-// The Result return will seem pointless on platforms that support all parity variants, but we need
-// it for the others.
-#[allow(clippy::unnecessary_wraps)]
-pub(crate) fn set_parity(termios: &mut Termios, parity: Parity) -> Result<()> {
+pub(crate) fn set_parity(termios: &mut Termios, parity: Parity) {
     match parity {
         Parity::None => {
             termios.c_cflag &= !(libc::PARENB | libc::PARODD);
@@ -173,22 +170,7 @@ pub(crate) fn set_parity(termios: &mut Termios, parity: Parity) -> Result<()> {
             termios.c_iflag &= !libc::IGNPAR;
             termios.c_iflag |= libc::CMSPAR;
         }
-        #[cfg(not(any(target_os = "linux", target_os = "android")))]
-        Parity::Mark => {
-            return Err(crate::Error::new(
-                crate::ErrorKind::InvalidInput,
-                "Mark parity not supported on this platform",
-            ));
-        }
-        #[cfg(not(any(target_os = "linux", target_os = "android")))]
-        Parity::Space => {
-            return Err(crate::Error::new(
-                crate::ErrorKind::InvalidInput,
-                "Space parity not supported on this platform",
-            ));
-        }
     };
-    Ok(())
 }
 
 pub(crate) fn set_flow_control(termios: &mut Termios, flow_control: FlowControl) {

--- a/src/posix/termios.rs
+++ b/src/posix/termios.rs
@@ -205,7 +205,6 @@ pub(crate) fn set_data_bits(termios: &mut Termios, data_bits: DataBits) {
 pub(crate) fn set_stop_bits(termios: &mut Termios, stop_bits: StopBits) {
     match stop_bits {
         StopBits::One => termios.c_cflag &= !libc::CSTOPB,
-        StopBits::OnePointFive => termios.c_cflag &= !libc::CSTOPB,
         StopBits::Two => termios.c_cflag |= libc::CSTOPB,
     };
 }

--- a/src/windows/com.rs
+++ b/src/windows/com.rs
@@ -352,6 +352,8 @@ impl COMPort {
         match dcb.Parity {
             ODDPARITY => Ok(Parity::Odd),
             EVENPARITY => Ok(Parity::Even),
+            MARKPARITY => Ok(Parity::Mark),
+            SPACEPARITY => Ok(Parity::Space),
             NOPARITY => Ok(Parity::None),
             _ => Err(Error::new(
                 ErrorKind::Unknown,

--- a/src/windows/com.rs
+++ b/src/windows/com.rs
@@ -366,6 +366,7 @@ impl COMPort {
         let dcb = dcb::get_dcb(self.handle.as_raw_handle())?;
         match dcb.StopBits {
             TWOSTOPBITS => Ok(StopBits::Two),
+            ONE5STOPBITS => Ok(StopBits::OnePointFive),
             ONESTOPBIT => Ok(StopBits::One),
             _ => Err(Error::new(
                 ErrorKind::Unknown,

--- a/src/windows/dcb.rs
+++ b/src/windows/dcb.rs
@@ -249,6 +249,8 @@ pub(crate) fn set_parity(dcb: &mut DCB, parity: Parity) {
         Parity::None => NOPARITY,
         Parity::Odd => ODDPARITY,
         Parity::Even => EVENPARITY,
+        Parity::Mark => MARKPARITY,
+        Parity::Space => SPACEPARITY,
     };
 
     dcb.set_fParity(parity != Parity::None);

--- a/src/windows/dcb.rs
+++ b/src/windows/dcb.rs
@@ -260,6 +260,7 @@ pub(crate) fn set_parity(dcb: &mut DCB, parity: Parity) {
 pub(crate) fn set_stop_bits(dcb: &mut DCB, stop_bits: StopBits) {
     dcb.StopBits = match stop_bits {
         StopBits::One => ONESTOPBIT,
+        StopBits::OnePointFive => ONE5STOPBITS,
         StopBits::Two => TWOSTOPBITS,
     };
 }

--- a/src/windows/dcb.rs
+++ b/src/windows/dcb.rs
@@ -1,7 +1,7 @@
 use std::mem::MaybeUninit;
 use windows_sys::Win32::Devices::Communication::{
-    GetCommState, SetCommState, DCB, EVENPARITY, MARKPARITY, NOPARITY, ODDPARITY, ONESTOPBIT,
-    SPACEPARITY, TWOSTOPBITS,
+    GetCommState, SetCommState, DCB, EVENPARITY, MARKPARITY, NOPARITY, ODDPARITY, ONE5STOPBITS,
+    ONESTOPBIT, SPACEPARITY, TWOSTOPBITS,
 };
 use windows_sys::Win32::Foundation::HANDLE;
 

--- a/src/windows/dcb.rs
+++ b/src/windows/dcb.rs
@@ -1,6 +1,7 @@
 use std::mem::MaybeUninit;
 use windows_sys::Win32::Devices::Communication::{
-    GetCommState, SetCommState, DCB, EVENPARITY, NOPARITY, ODDPARITY, ONESTOPBIT, TWOSTOPBITS,
+    GetCommState, SetCommState, DCB, EVENPARITY, MARKPARITY, NOPARITY, ODDPARITY, ONESTOPBIT,
+    SPACEPARITY, TWOSTOPBITS,
 };
 use windows_sys::Win32::Foundation::HANDLE;
 


### PR DESCRIPTION
Implements the approach discussed in #302 for PRs #189 and #195 instead of exposing unsupported variants and failing at runtime, gate them behind `#[cfg()]` and mark the enums `#[non_exhaustive]`.

## Changes
 
**Parity** (from #189, original work by @YgorSouza)
- `Parity::Mark` and `Parity::Space` gated to `windows`, `linux`, `android`
- `Parity` marked `#[non_exhaustive]`
- POSIX: clears/sets `CMSPAR` flag on linux/android
- Windows: maps to `MARKPARITY`/`SPACEPARITY`


**StopBits** (from #195, original work by @robdobsn)
- `StopBits::OnePointFive` gated to `windows`
- `StopBits` marked `#[non_exhaustive]`
- Windows: maps to `ONE5STOPBITS`



## Downstream impact analysis
 
Scanned 300+ dependent crates of serialport 4.9.0 for usage patterns, weighted by crates.io download counts.
 
**Parity usage (134 crates reference it):**
- ~45 only set parity via the builder (write-only, unaffected)
- ~11 read parity back via `.parity()`
- ~29 match on parity, but only ~9 match on `serialport::Parity` directly the rest match on their own wrapper types
- 1 crate uses Mark/Space (`rtcom-core`, 143 downloads) collapses both to `Parity::None` silently

**StopBits:** 168 crates reference `StopBits::One`, zero reference `OnePointFive` (doesn't exist yet).


**Tested against downstream crates** by patching their `Cargo.toml` to point at this branch:
- `stuart-cli`: `E0004: non-exhaustive patterns` 
- `rfc2217-rs`: `E0004: non-exhaustive patterns` 
- `serialport-stream`: `E0004: non-exhaustive patterns` 
All got compile-time errors forcing explicit handling of new variants no silent runtime failures.
