### PR TITLE
feat: add a 9-bit sized character option

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,6 +153,9 @@ pub enum DataBits {
 
     /// 8 bits per character
     Eight,
+
+    /// 9 bits per character
+    Nine,
 }
 
 impl fmt::Display for DataBits {


### PR DESCRIPTION
Used by some embedded applications.